### PR TITLE
Add .desktop file for packaging

### DIFF
--- a/goverlay.desktop
+++ b/goverlay.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=GOverlay
+GenericName=Overlay configuration
+Comment=Graphical UI to help manage Linux overlays
+Exec=goverlay
+Icon=goverlay
+Terminal=false
+Type=Application
+Categories=Graphics;


### PR DESCRIPTION
To place in `/usr/share/applications` for system-wide integration.

There's no icon for the application yet though, the two `.ico` files seem to be generic Lazarus icons. (And a Linux icon should be in `.png` or `.svg`.)