### PR TITLE
Add Fedora installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ ARCH / Manjaro Linux and derivatives
 
 <code>goverlay-git</code> is now avaiable on the AUR, install it with your favourite AUR helper. 
 
+Fedora
+
+<code>sudo dnf install goverlay</code>
 
 Ubuntu / Debian
 


### PR DESCRIPTION
Hello. Goverlay packaged and available in official Fedora repos now. Now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2020-37ac6b56e2), so better hold a little bit this PR until Bodhi pushed it to Stable repos.