### PR TITLE
add .desktop keywords

### DIFF
--- a/goverlay.desktop
+++ b/goverlay.desktop
@@ -7,3 +7,4 @@ Icon=goverlay
 Terminal=false
 Type=Application
 Categories=Graphics;
+Keywords=MangoHud;vkBasalt;


### PR DESCRIPTION
Keywords help when searching for software, see [here](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html).
tl;dr: if you search "MangoHud" or "vkBasalt" then GOverlay should appear as well.