### PR TITLE
add appstream metainfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOverlay
 
-GOverlay is an open source project aimed to create a Graphical UI to manage Linux overlays. It is still in early development, so it lacks a lot of features.
+GOverlay is an open source project aimed to create a Graphical UI to manage Vulkan/OpenGL overlays. It is still in early development, so it lacks a lot of features.
 
 This project was only possible thanks to the other maintainers and contributors that have done the hard work. I am just a Network Engineer that really likes Linux and Gaming.
 

--- a/goverlay.desktop
+++ b/goverlay.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=GOverlay
 GenericName=Overlay configuration
-Comment=Graphical UI to help manage Linux overlays
+Comment=Graphical UI to help manage Vulkan/OpenGL overlays
 Exec=goverlay
 Icon=goverlay
 Terminal=false

--- a/goverlay.metainfo.xml
+++ b/goverlay.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.benjamimgois.goverlay</id>
+  
+  <name>GOverlay</name>
+  <summary>Graphical UI to help manage Vulkan/OpenGL overlays</summary>
+  
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  
+  <description>
+    <p>
+      GOverlay can configure Vulakn/OpenGL overlays with a live preview. Currently supported are the MangoHud and the vkBasalt overlays.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">goverlay.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Options for MangoHud</caption>
+      <image>https://i.ibb.co/wCBVdXh/goverlay-0-3.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Options for vkBasalt</caption>
+      <image>https://i.ibb.co/C9XhdRx/goverlay-0-3-2.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <url type="homepage">https://github.com/benjamimgois/goverlay</url>
+  <url type="bugtracker">https://github.com/benjamimgois/goverlay/issues</url>
+</component>


### PR DESCRIPTION
Based on #17.

Adds a metainfo for appstream, i.e. makes it searchable by GNOME Software, KDE Discover etc. I created it with https://www.freedesktop.org/software/appstream/metainfocreator, I've chosen the FSF All Permissive License for the metainfo (doesn't require any copyright notice) and GPL v3 or later in SPDX >=3.0 style.

Note that I included the screenshots, if you change them you should change them in the metainfo file as well.

Btw it's also possible to add a release history to the metainfo, here is an example metainfo file that does this: https://github.com/cvfosammmm/Setzer/blob/master/data/org.cvfosammmm.Setzer.appdata.xml