### PR TITLE
file permissions and man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 prefix = /usr/local
-
 bindir = /bin
 datadir = /share
 
@@ -13,12 +12,12 @@ clean:
 	rm -Rf lib
 
 install: goverlay
-	install -D goverlay $(DESTDIR)$(prefix)$(bindir)/goverlay
-	install -D data/goverlay.desktop $(DESTDIR)$(prefix)$(datadir)/applications/goverlay.desktop
-	install -D data/goverlay.metainfo.xml $(DESTDIR)$(prefix)$(datadir)/metainfo/goverlay.metainfo.xml
-	install -D data/icons/128x128/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/128x128/apps/goverlay.png
-	install -D data/icons/256x256/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/256x256/apps/goverlay.png
-	install -D data/icons/512x512/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/512x512/apps/goverlay.png
+	install -D -m=755 goverlay $(DESTDIR)$(prefix)$(bindir)/goverlay
+	install -D -m=644 data/goverlay.desktop $(DESTDIR)$(prefix)$(datadir)/applications/goverlay.desktop
+	install -D -m=644 data/goverlay.metainfo.xml $(DESTDIR)$(prefix)$(datadir)/metainfo/goverlay.metainfo.xml
+	install -D -m=644 data/icons/128x128/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/128x128/apps/goverlay.png
+	install -D -m=644 data/icons/256x256/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/256x256/apps/goverlay.png
+	install -D -m=644 data/icons/512x512/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/512x512/apps/goverlay.png
 
 uninstall:
 	rm -f $(DESTDIR)$(prefix)$(bindir)/goverlay

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install: goverlay
 	install -D -m=755 goverlay $(DESTDIR)$(prefix)$(bindir)/goverlay
 	install -D -m=644 data/goverlay.desktop $(DESTDIR)$(prefix)$(datadir)/applications/goverlay.desktop
 	install -D -m=644 data/goverlay.metainfo.xml $(DESTDIR)$(prefix)$(datadir)/metainfo/goverlay.metainfo.xml
+	install -D -m=644 data.goverlay.1 $(DESTDIR)$(prefix)$(datadir)/man/man1/goverlay.1
 	install -D -m=644 data/icons/128x128/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/128x128/apps/goverlay.png
 	install -D -m=644 data/icons/256x256/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/256x256/apps/goverlay.png
 	install -D -m=644 data/icons/512x512/goverlay.png $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/512x512/apps/goverlay.png
@@ -23,6 +24,7 @@ uninstall:
 	rm -f $(DESTDIR)$(prefix)$(bindir)/goverlay
 	rm -f $(DESTDIR)$(prefix)$(datadir)/applications/goverlay.desktop
 	rm -f $(DESTDIR)$(prefix)$(datadir)/metainfo/goverlay.metainfo.xml
+	rm -f $(DESTDIR)$(prefix)$(datadir)/man/man1/goverlay.1
 	rm -f $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/128x128/apps/goverlay.png
 	rm -f $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/256x256/apps/goverlay.png
 	rm -f $(DESTDIR)$(prefix)$(datadir)/icons/hicolor/512x512/apps/goverlay.png

--- a/data/goverlay.1
+++ b/data/goverlay.1
@@ -1,0 +1,7 @@
+.TH goverlay 1 "" "" ""
+.SH NAME
+goverlay \- Graphical UI to help manage Vulkan/OpenGL overlays
+.SH SYNOPSIS
+\fBgoverlay\fR
+.SH DESCRIPTION
+\fBGOverlay\fR can configure Vulakn/OpenGL overlays with a live preview. Currently supported are the MangoHud and the vkBasalt overlays.


### PR DESCRIPTION
While packaging GOverlay for Debian I noticed two things:
- every file is executable (which is really bad)
- there should be a man page (every file in /usr/bin should have one)

 So this fixes it. To preview the man page you can run `man -l data/goverlay.1`.