### PR TITLE
make executable position independent

### DIFF
--- a/goverlay.lpi
+++ b/goverlay.lpi
@@ -96,6 +96,9 @@
         </Win32>
       </Options>
     </Linking>
+    <Other>
+      <CustomOptions Value="-fPIC"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions Count="3">


### PR DESCRIPTION
Currently, goverlay doesn't have position independent code (short PIC or PIE, https://en.wikipedia.org/wiki/Position-independent_code). This is actually creates a warning when building this for Debian, since PIEs are required for Address Space Layout Randomization: https://lintian.debian.org/tags/hardening-no-pie.html

Pascal supports this by adding `-fPIC` or `-Cg` to the compile arguments: https://www.freepascal.org/docs-html/current/user/usersu15.html#x38-450005.1.4
They say it's only needed for libraries since it can theoretically hurt performance, but Debian disagrees and I do as well. I didn't notice any performance regression anyway.
