### PR TITLE
Correct Arch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,18 @@ Here are the dependencies needed in order to make GOverlay run:
 
 #### Arch / Manjaro / Other Arch derivatives
 
-Install it from the AUR [`goverlay-git`](https://aur.archlinux.org/packages/goverlay-git/) (need to download Lazarus and all compilation packages) or from the [`chaotic-AUR`](http://lonewolf-builder.duckdns.org/chaotic-aur) (download just the latest binary binary). Run the following command as root:
+Install the development package from the AUR [`goverlay-git`](https://aur.archlinux.org/packages/goverlay-git/). You can use an AUR Helper like `yay` or `pamac`:
 
 ```bash
-pacman -S goverlay-git
+yay -S goverlay-git
 ```
 or
 
 ```bash
 pamac install goverlay-git
 ```
+
+You can also install the binary package from [`chaotic-AUR`](http://lonewolf-builder.duckdns.org/chaotic-aur) (unofficial Arch repo).
 
 #### Fedora
 


### PR DESCRIPTION
AUR packages can't be installed with `pacman`.