### PR TITLE
add category "Gaming" to .desktop file

### DIFF
--- a/data/goverlay.desktop
+++ b/data/goverlay.desktop
@@ -6,5 +6,5 @@ Exec=goverlay
 Icon=goverlay
 Terminal=false
 Type=Application
-Categories=Graphics;
+Categories=Graphics;Gaming;
 Keywords=MangoHud;vkBasalt;


### PR DESCRIPTION
While browsing through my applications menu I noticed GOverlay is only shown in the "Graphics" category, but I think it should be shown in the "Games" category as well.