### PR TITLE
add optional build options to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ datadir = /share
 all: goverlay
 
 goverlay:
-	lazbuild -B goverlay.lpi
+	lazbuild -B goverlay.lpi $(LAZBUILDOPTS)
 
 clean:
 	rm -f goverlay


### PR DESCRIPTION
For example the AUR package needs to build the `--lazarusdir=/usr/lib/lazarus`, so it is a good idea to implement that additional build options can be set with make.

/cc @yochananmarqos