### PR TITLE
make make aware of code changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ datadir = /share
 
 all: goverlay
 
-goverlay:
+goverlay: *.pas *.lfm *.lrs goverlay.lpi goverlay.lpr goverlay.lps goverlay.res goverlay.ico
 	lazbuild -B goverlay.lpi $(LAZBUILDOPTS)
 
 clean:
 	rm -f goverlay
-	rm -Rf lib
+	rm -rf lib/
 
 install: goverlay
 	install -D -m=755 goverlay $(DESTDIR)$(prefix)$(bindir)/goverlay


### PR DESCRIPTION
This basically tells make which files are responsible for building the `goverlay` file. If any of those changes, running `make` will automatically regenerate `goverlay`, if they don't change make won't.

It's not really necessary here, it could also just be a phony target (i. e. always run the code).