### PR TITLE
enable Release mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ datadir = /share
 all: goverlay
 
 goverlay: *.pas *.lfm *.lrs goverlay.lpi goverlay.lpr goverlay.lps goverlay.res goverlay.ico
-	lazbuild -B goverlay.lpi $(LAZBUILDOPTS)
+	lazbuild -B goverlay.lpi --bm=Release $(LAZBUILDOPTS)
 
 clean:
 	rm -f goverlay


### PR DESCRIPTION
This will enable the Release mode from #64 by default when building with make. Usually this isn't really wished since when developing one doesn't want the Release mode, but since development is done via Lazarus and make is basically only used for the installation, it's not a problem.