### PR TITLE
fix showing red dot when MangoHud is the only missing dependency

### DIFF
--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -4966,6 +4966,7 @@ begin
         if (mangohuddependencyVALUE = 0) and ( vkbasaltdependencyVALUE = 1) and ( replaydependencyVALUE = 1 ) then
         begin
         dependenciesLabel.Caption:= 'Missing MangoHud';
+        dependencieSpeedButton.ImageIndex := 1;
         end;
 
         if (mangohuddependencyVALUE = 1) and ( vkbasaltdependencyVALUE = 0) and ( replaydependencyVALUE = 1 ) then


### PR DESCRIPTION
Currently, if MangoHud is the only missing dependency, a green dot will be displayed beside the message.

![image](https://user-images.githubusercontent.com/382041/116798137-b14a2f00-aaba-11eb-8aef-107e1351eda2.png)
