### PR TITLE
Update README and start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ tar -zxvf goverlay*.tar.gz
 3. Properly execute the binary by running the script inside the tar file:
 
 ```bash
-chmod +x start_goverlay.sh
 ./start_goverlay.sh
 ```
 
+Note: Since version 0.6.4 mangohud needs to be installed to run GOverlay.
 
 ## Source
 
@@ -153,20 +153,23 @@ make
 
 ### Running
 
-Starting in 0.6.2 version you'll need mangohud installed to run GOverlay, run the following command:
+Start GOverlay with:
 
 ```bash
-mangohud --dlsym ./goverlay --style fusion
+./start_goverlay.sh
 ```
 
+Note: Since version 0.6.4 mangohud needs to be installed to run GOverlay.
 
-### Wayland
+### Installing
 
-QT5PAS still isn't compatible with wayland display server, but you can run the application by forcing the x11 backend. Credits by [**`Darklink999999`**](https://github.com/Darklink999999)
+To install GOverlay execute:
 
 ```bash
-QT_QPA_PLATFORM=xcb mangohud --dlsym goverlay --style fusion
+make install
 ```
+
+This will install the start script to `/usr/local/bin/goverlay`, so that it can be launched via `goverlay` in the console. 
 
 ## Credits
 

--- a/start_goverlay.sh
+++ b/start_goverlay.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-# This script will Launch Goverlay the correct way
+# This script will launch the compiled goverlay binary the correct way
 #
 # QT_QPA_PLATFORM=xcb will force the application to run in x11 mode, so it works on wayland desktops.
-# mangohud --dlsym will force the mangohud display on the spinning cube on goverlay
+# mangohud --dlsym will force the mangohud display on the spinning cube on goverlay.
 # --style fusion will make sure the interface doesn't break in diferent DE and QT themes.
 
-QT_QPA_PLATFORM=xcb mangohud --dlsym goverlay --style fusion
+export QT_QPA_PLATFORM=xcb
+mangohud --dlsym ./goverlay --style fusion


### PR DESCRIPTION
This PR makes the start script executable (to omit the `chmod +x`) and force it to use the local binary (`./goverlay` instead of `goverlay`).
I also updated the readme to for this and replaced the wayland section with an install section.