### PR TITLE
chmod fix + tarball target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/goverlay.sh
 lib/
 backup/
 goverlay.lps
+goverlay_*.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ data/goverlay.sh: data/goverlay.sh.in
 
 start_goverlay.sh: data/goverlay.sh.in
 	sed s%@libexecdir@%.%g data/goverlay.sh.in > start_goverlay.sh
+	chmod +x ./start_goverlay.sh
 
 clean:
 	rm -f goverlay

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ clean:
 	rm -f data/goverlay.sh
 	rm -rf lib/
 	rm -rf backup/
-	rm -rf goverlay.lps
+	rm -f goverlay.lps
+	rm -f goverlay_*.tar.xz
 
 install: goverlay data/goverlay.sh
 	install -D -m=755 goverlay $(DESTDIR)$(prefix)$(libexecdir)/goverlay
@@ -47,4 +48,7 @@ tests:
 	appstreamcli validate --pedantic data/io.github.benjamimgois.goverlay.metainfo.xml
 	desktop-file-validate data/io.github.benjamimgois.goverlay.desktop
 
-.PHONY: all data/goverlay.sh start_goverlay.sh clean install uninstall tests
+tarball: goverlay start_goverlay.sh
+	tar -cJf goverlay_${VERSION}.tar.xz goverlay start_goverlay.sh
+
+.PHONY: all data/goverlay.sh start_goverlay.sh clean install uninstall tests tarball


### PR DESCRIPTION
This fixes the a missing `chmod +x` for `start_goverlay.sh`, sorry for forgetting^^

As a goodie I added a `make tarball` target, you can use it to automatically create the tarball for the release including the binary and the start script. You only need to add the version via an environment variable, e.g. `env VERSION=0_7_1 make tarball`.