### PR TITLE
Remove start_script.sh again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ data/goverlay.sh: data/goverlay.sh.in
 
 start_goverlay.sh: data/goverlay.sh.in
 	sed s%@libexecdir@%.%g data/goverlay.sh.in > start_goverlay.sh
-	chmod +x ./start_goverlay.sh
+	chmod +x start_goverlay.sh
 
 clean:
 	rm -f goverlay

--- a/start_goverlay.sh
+++ b/start_goverlay.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# This script will Launch Goverlay the correct way
-#
-# QT_QPA_PLATFORM=xcb will force the application to run in x11 mode, so it works on wayland desktops.
-# mangohud --dlsym will force the mangohud display on the spinning cube on goverlay
-# --style breeze will make sure the interface doesn't break in diferent DE and QT themes.
-
-QT_QPA_PLATFORM=xcb mangohud --dlsym ./goverlay --style breeze


### PR DESCRIPTION
Can be created from `data/goverlay.sh.in` by either running `make` or `make start_goverlay.sh`.