### PR TITLE
Fix link to Lazarus

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Note: Since version 0.6.4 mangohud needs to be installed to run GOverlay.
 
 Before building, you will need to install the following:
 
- - [Lazarus](https://github.com/graemeg/lazarus) - IDE
+ - [Lazarus](https://gitlab.com/freepascal.org/lazarus/lazarus) - IDE
 
 ### Building
 


### PR DESCRIPTION
This PR fixes the readme file by updating the dead link to the Lazarus repo in the prerequisites sub-section of the source section.

Alternatives to the [gitlab link](https://gitlab.com/freepascal.org/lazarus/lazarus) that is included in the PR could be:
- https://github.com/fpc/Lazarus (The github mirror)
- https://www.lazarus-ide.org/ (The Lazarus website)