### PR TITLE
Add possibility to execute with style option

### DIFF
--- a/data/goverlay.1
+++ b/data/goverlay.1
@@ -2,6 +2,12 @@
 .SH NAME
 goverlay \- Graphical UI to help manage Vulkan/OpenGL overlays
 .SH SYNOPSIS
-\fBgoverlay\fR
+\fBgoverlay [--style STYLE]\fR
 .SH DESCRIPTION
 \fBGOverlay\fR can configure Vulkan / OpenGL overlays with a preview. Currently supported are MangoHud, vkBasalt and ReplaySorcery.
+.SH OPTIONS
+.TP 8
+.B --style STYLE
+Force a specific Qt style. An alternative to this option is setting the QT_STYLE_OVERRIDE enviroment variable.
+.SH NOTE
+It is recommended to use the Breeze (Qt/KDE) or Adwaita (Gtk/Gnome) theme.

--- a/data/goverlay.sh.in
+++ b/data/goverlay.sh.in
@@ -3,7 +3,7 @@
 #
 # QT_QPA_PLATFORM=xcb will force the application to run in x11 mode, so it works on wayland desktops.
 # mangohud --dlsym will force the mangohud display on the spinning cube on goverlay.
-# --style Breeze will make sure the interface doesn't break in diferent DE and QT themes.
+# Executing this script with --style <style> one can choose different themes.
 
 export QT_QPA_PLATFORM=xcb
-mangohud --dlsym @libexecdir@/goverlay
+mangohud --dlsym @libexecdir@/goverlay $@


### PR DESCRIPTION
This allows to run e.g. `goverlay --style adwaita` and `goverlay --style breeze` to test different themes.