### PR TITLE
Read from the os-release file instead of using lsb-release so that go…

### DIFF
--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -1674,13 +1674,13 @@ begin
 RunCommand('bash -c ''echo "custom_text= #add line for space" >> $HOME/.config/MangoHud/MangoHud.conf''', s);
 RunCommand('bash -c ''echo "custom_text=Distro:" >> $HOME/.config/MangoHud/MangoHud.conf''', s);  //insert Custom text in mangohud.conf
 RunCommand('bash -c ''rm -rf $HOME/.config/goverlay/distroinfo''', s);      // remove old file
-RunCommand('bash -c ''lsb_release -a | grep Description | cut -c 14-26 >> $HOME/.config/goverlay/distroinfo''', s);      // store distro name in goverlay folder
+RunCommand('bash -c ''cat /usr/lib/os-release | grep -w NAME | cut -d "=" -f2 | cut -d "\"" -f 2 >> $HOME/.config/goverlay/distroinfo''', s);      // store distro name in goverlay folder
 RunCommand('bash -c ''echo "exec=cat $HOME/.config/goverlay/distroinfo" >> $HOME/.config/MangoHud/MangoHud.conf''', s); // read the text file in goverlay folder
 
 //Distro version
 RunCommand('bash -c ''echo "custom_text=Version:" >> $HOME/.config/MangoHud/MangoHud.conf''', s); //insert Custom text in mangohud.conf
 RunCommand('bash -c ''rm -rf $HOME/.config/goverlay/distroversion''', s);      // remove old file
-RunCommand('bash -c ''lsb_release -a | grep Release | cut -c 10-26 >> $HOME/.config/goverlay/distroversion''', s);      // store distro name in goverlay folder
+RunCommand('bash -c ''cat /usr/lib/os-release | grep VERSION_ID | cut -d "=" -f2 >> $HOME/.config/goverlay/distroversion''', s);      // store distro name in goverlay folder
 RunCommand('bash -c ''echo "exec=cat $HOME/.config/goverlay/distroversion" >> $HOME/.config/MangoHud/MangoHud.conf''', s); // read the text file in goverlay folder
 
 //kernel version


### PR DESCRIPTION
…verlay does not require lsb-release

I have a Fedora spin that was not picking up the Distro and version in MangoHud:

![Screenshot from 2022-07-31 12-56-14](https://user-images.githubusercontent.com/11287837/182042763-6842f829-5844-4816-83aa-6f92eab40932.png)

 Upon further inspection, I found this was controlled by goverlay:

```
custom_text=Distro:
exec=cat /home/tcrider/.config/goverlay/distroinfo
custom_text=Version:
exec=cat /home/tcrider/.config/goverlay/distroversion
custom_text=Kernel:
exec=cat /home/tcrider/.config/goverlay/kernelversion
```

And Goverlay was setting these blank, but it worked fine in normal Fedora. 

After looking at the code I found that Goverlay is using `lsb-release` to gather OS information, which was not installed on my system and the providing package for it was not required as a dependency.

Instead of installing the package, I modified the code so that it reads the /usr/lib/os-release file present on every distro and uses the NAME and VERSION_ID values. MangoHud also does something similar to this:

https://github.com/flightlessmango/MangoHud/blob/05133ae3cd05285c4cf373896dd0ce2a6e4e4169/src/overlay.cpp#L783
https://github.com/flightlessmango/MangoHud/blob/05133ae3cd05285c4cf373896dd0ce2a6e4e4169/build.sh#L4
https://github.com/flightlessmango/MangoHud/blob/05133ae3cd05285c4cf373896dd0ce2a6e4e4169/bin/mangohud-setup.sh#L2

Note that /etc/os-release is always symlinked to /usr/lib/os-release so you don't need to check both. My patch checks /usr/lib/os-release directly. This avoids having an extra dependency/reliance on the lsb-release command. My patch also uses NAME instead of PRETTY_NAME for a few reasons:

1. PRETTY_NAME also appends the version, while NAME does not. Since we already gather the version separately this is unnecessary
2. Some distros like to tack on additional items to the PRETTY_NAME in parenthesis, like "Fedora Linux 36 (KDE Plasma)" which is unnecessary and too long.

Final appearance after changes:


![Screenshot from 2022-07-31 14-24-43](https://user-images.githubusercontent.com/11287837/182043983-253d99ad-d5c5-4997-8c75-1429684a3e29.png)

