### PR TITLE
revert to writing os and version to separate file and just having man…

### DIFF
--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -1674,10 +1674,10 @@ begin
 RunCommand('bash -c ''echo "custom_text= #add line for space" >> $HOME/.config/MangoHud/MangoHud.conf''', s);
 
 // Distro name
-RunCommand('bash -c ''echo "custom_text=Distro:" >> $HOME/.config/MangoHud/MangoHud.conf; echo "exec=cat /usr/lib/os-release | grep -w NAME | cut -d \"=\" -f2 | cut -d \"\\\"\" -f 2" >> $HOME/.config/MangoHud/MangoHud.conf''', s);      // store distro name in goverlay folder
+RunCommand('bash -c ''echo "custom_text=Distro:" >> $HOME/.config/MangoHud/MangoHud.conf; cat /usr/lib/os-release | grep -w NAME | cut -d "=" -f2 | cut -d "\"" -f 2 > $HOME/.config/goverlay/distroinfo ;echo "exec=cat $HOME/.config/goverlay/distroinfo" >> $HOME/.config/MangoHud/MangoHud.conf''', s);      // store distro name in goverlay folder
 
 //Distro version
-RunCommand('bash -c ''echo "custom_text=Version:" >> $HOME/.config/MangoHud/MangoHud.conf; echo "exec=VERSION=\$(cat /usr/lib/os-release | grep VERSION_ID | cut -d \"=\" -f2);if [[ \"\$VERSION\" == \"\" ]]; then VERSION=\$(cat /usr/lib/os-release | grep BUILD_ID | cut -d \"=\" -f2); fi; if [[ "\$VERSION" != \"\" ]]; then echo \$VERSION; else echo rolling; fi" >> $HOME/.config/MangoHud/MangoHud.conf''', s);      // store distro name in goverlay folder
+RunCommand('bash -c ''echo "custom_text=Version:" >> $HOME/.config/MangoHud/MangoHud.conf; VERSION=$(cat /usr/lib/os-release | grep VERSION_ID | cut -d "=" -f2);if [[ "$VERSION" == "" ]]; then VERSION=$(cat /usr/lib/os-release | grep BUILD_ID | cut -d "=" -f2); fi; if [[ "$VERSION" != "" ]]; then echo $VERSION > $HOME/.config/goverlay/distroversion; else echo rolling > $HOME/.config/goverlay/distroversion; fi;echo "exec=cat $HOME/.config/goverlay/distroversion" >> $HOME/.config/MangoHud/MangoHud.conf''', s);      // store distro name in goverlay folder
 
 //kernel version
 RunCommand('bash -c ''echo "custom_text=Kernel:" >> $HOME/.config/MangoHud/MangoHud.conf; echo "exec=uname -r" >> $HOME/.config/MangoHud/MangoHud.conf''', s);


### PR DESCRIPTION
…gohud read it

The latest steam runtime implemented their own os-release and lsb_release information,
so now it just says 'Steam Runtime' for the distro. When using lsb-release it just
comes out blank. This reverts one change so that the os and version are written to separate files (like it did before),
this way mangohud just reads the already existing custom files instead of pulling them
from Valve's runtime.

Signed-off-by: Thomas Crider <gloriouseggroll@gmail.com>

Broken with os-release:
![Screenshot from 2022-08-12 12-34-30](https://user-images.githubusercontent.com/11287837/184428742-725f19a9-2c84-4fe8-ad53-d6355960539c.png)

Broken with lsb_release:
![Screenshot from 2022-08-12 13-07-24](https://user-images.githubusercontent.com/11287837/184428794-27f74766-db27-4915-a736-615a680244fa.png)

This patch with os-release and os + version written to separate file before game launch:
![Screenshot from 2022-08-12 13-19-11](https://user-images.githubusercontent.com/11287837/184428847-fb4727c5-379a-4c93-b116-6eccb589eac7.png)

