### PR TITLE
Update installation instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Here are the dependencies needed in order to make GOverlay run:
 
 #### Arch / Manjaro / Other Arch derivatives
 
-[`goverlay-bin`](https://aur.archlinux.org/packages/goverlay-bin/) is in the AUR. You can install it using your favourite AUR helper. You can also grab the latest git code with [`goverlay-git`](https://aur.archlinux.org/packages/goverlay-git/). The repository  [`chaotic-aur`](https://lonewolf.pedrohlc.com/chaotic-aur/) provides the binaries from the latest GIT code.
+To install [`goverlay`](https://archlinux.org/packages/extra/x86_64/goverlay/), run the following command as root:
 
 ```bash
-pamac install goverlay-bin
+pacman -S goverlay
 ```
 
 #### Fedora


### PR DESCRIPTION
Goverlay is now in the [official Arch [extra] repository](https://archlinux.org/packages/extra/x86_64/goverlay/).

This PR aims to update the `Arch / Manjaro / Other Arch derivatives` installation instructions accordingly. I used the same wording as the Fedora instructions.

I remain available if needed :)