### PR TITLE
Fix broken gpu model checkbox.

### DIFF
--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -1874,7 +1874,7 @@ var
         Savecheckbox (gputhrottlinggraphCheckbox, GPUTHRG, 'throttling_status_graph');
 
         //GPU MODEL   - Config Variable
-        Savecheckbox (gpumodelCheckbox, GPUTHRG, 'gpu_name');
+        Savecheckbox (gpumodelCheckbox, GPUMODEL, 'gpu_name');
 
         //VULKAN DRIVER   - Config Variable
         Savecheckbox (vulkandriverCheckbox, VULKANDRIVER, 'vulkan_driver');


### PR DESCRIPTION
I checked mangohud to verifu gpu_name was working when added manually. I then checked the code here and found the gpu model checkbox had incorrect value set (GPUTHRG) so it wasn't working. This correctly sets it to GPUMODEL