### PR TITLE
use iculess packages to reduce size of appimage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -57,9 +57,24 @@ jobs:
 
       - name: Install debloated llvm-libs
         run: |
-          LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
-          wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
+          LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
+          wget --retry-connrefused --tries=30 "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
           pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
+          rm -f ./llvm-libs.pkg.tar.zst
+  
+      - name: Install iculess libxml2
+        run: |
+          LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
+          wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
+          pacman -U --noconfirm ./libxml2-iculess.pkg.tar.zst
+          rm -f ./libxml2-iculess.pkg.tar.zst
+
+      - name: Install iculess qt6-base
+        run: |
+          QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-x86_64.pkg.tar.zst"
+          wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base.pkg.tar.zst
+          pacman -U --noconfirm ./qt6-base.pkg.tar.zst
+          rm -f ./qt6-base.pkg.tar.zst
 
       # Runs a set of commands using the runners shell
       - name: Build GOverlay


### PR DESCRIPTION
This makes the AppImage 64 MiB.

* libxml2 by default does not compile linking to libicudata, distros change this because thunderbird does need, and it seems to be the only application that does. 

* qt6-base does link to libicudata by default, but because qt-webengine needs it, which goverlay is not making use of.