### PR TITLE
bundle lspci

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -53,7 +53,8 @@ jobs:
             qt6pas \
             vulkan-tools \
             qt6-wayland \
-            lazarus
+            lazarus \
+            pciutils
 
       - name: Install debloated llvm-libs
         run: |

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -27,6 +27,7 @@ xvfb-run -a -- ./lib4bin -p -v -e -s -k \
 	/usr/lib/mangohud/* \
 	/usr/bin/vkcube \
 	/usr/bin/vkcube-wayland \
+	/usr/bin/lspci \
 	/usr/lib/qt6/plugins/iconengines/* \
 	/usr/lib/qt6/plugins/imageformats/* \
 	/usr/lib/qt6/plugins/platforms/* \

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -2405,7 +2405,7 @@ GPUBrand := '';
  GPUInfo := TStringList.Create;
  try
    // Execute the command lspci to list PCI devices
-   AProcess.Executable := '/usr/bin/lspci';
+   AProcess.Executable := 'lspci';
    AProcess.Parameters.Add('-nn');
    AProcess.Options := [poWaitOnExit, poUsePipes];
    AProcess.Execute;


### PR DESCRIPTION
The binary is tiny and depends on libs already found in the appimage, so it makes sense to add for the people that don't have the pciutils package installed. 

However this is not working yet, because goverlay looks to be hardcoded to try `/usr/bin/lspci` instead of `lspci` in `PATH` 👀

I can actually fix this with binary patching by running 
```
sed -i 's|/usr/bin/lspci|././/bin/lspci|' ./shared/bin/goverlay

```

Tested it and it works, but this is usually a last resort solution. The ideal solution is for goverlay to try the `lspci` in PATH instead of having that hardcoded, let me know anyways. 