### PR TITLE
Simplify appimage script, recreate nightly tag so that it doesn't get burried below newer releases

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -33,7 +33,6 @@ jobs:
             wget \
             git \
             artix-archlinux-support \
-            llvm \
             mesa \
             mangohud \
             xorg-server-xvfb \

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -111,6 +111,14 @@ jobs:
         with:
           name: AppImage
 
+      - name: Delete previous pre-release
+        run: |
+          gh release delete "nightly" --repo "${GITHUB_REPOSITORY}" --cleanup-tag  -y
+          sleep 5
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        continue-on-error: true
+
       - name: Create pre-release
         uses: softprops/action-gh-release@v2
         if: ${{ github.ref_name == 'main' }}

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -5,7 +5,7 @@ set -eu
 # make appimage
 export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
-export VERSION="$GITHUB_SHA"
+export VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -8,9 +8,7 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 export VERSION=git
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
-URUNTIME=$(wget --retry-connrefused --tries=30 \
-	https://api.github.com/repos/VHSgunzo/uruntime/releases -O - \
-	| sed 's/[()",{} ]/\n/g' | grep -oi "https.*appimage.*dwarfs.*$ARCH$" | head -1)
+URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
 
 # Prepare AppDir
 mkdir -p ./AppDir
@@ -60,17 +58,13 @@ chmod +x ./uruntime
 
 # Add udpate info to runtime
 echo "Adding update information \"$UPINFO\" to runtime..."
-printf "$UPINFO" > data.upd_info
-
-llvm-objcopy --update-section=.upd_info=data.upd_info \
-	--set-section-flags=.upd_info=noload,readonly ./uruntime
-printf 'AI\x02' | dd of=./uruntime bs=1 count=3 seek=8 conv=notrunc
+./uruntime --appimage-addupdinfo "$UPINFO"
 
 echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B16 \
+	--compression zstd:level=22 -S24 -B32 \
 	--header uruntime \
 	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -5,7 +5,7 @@ set -eu
 # make appimage
 export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
-export VERSION=git
+export VERSION="$(git rev-parse --short HEAD)"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -64,7 +64,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B32 \
+	--compression zstd:level=22 -S25 -B32 \
 	--header uruntime \
 	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -5,7 +5,7 @@ set -eu
 # make appimage
 export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
-export VERSION="$(git rev-parse --short HEAD)"
+export VERSION="$GITHUB_SHA"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"


### PR DESCRIPTION
This PR simplfiies the appimage script. 

* zsync info is now added by the uruntime instead of using `llvm-objcopy`

* No longer parse github releases to get the lastest uruntime release, github provides a link that does it xd

* Now instead of "git" the version in the appimage title will be the last commit short hash.

* The nightly tag gets recreated with each CI run, since most people won't notice [this](https://github.com/benjamimgois/goverlay/releases/tag/nightly) gets updated