### PR TITLE
fix and optimize grep

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -112,6 +112,7 @@ jobs:
           name: AppImage
 
       - name: Delete previous pre-release
+        if: ${{ github.ref_name == 'main' }}
         run: |
           gh release delete "nightly" --repo "${GITHUB_REPOSITORY}" --cleanup-tag  -y
           sleep 5

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -466,7 +466,7 @@ begin
 
   CaminhoArquivo := GetEnvironmentVariable('HOME') + '/.config/MangoHud/MangoHud.conf';
 
-  Process.Executable := '/bin/bash';
+  Process.Executable := 'sh';
   Process.Parameters.Add('-c');
   Process.Parameters.Add('cat ' +  CaminhoArquivo);
   Process.Options := [poUsePipes];
@@ -498,9 +498,9 @@ begin
 
   CaminhoArquivo := GetEnvironmentVariable('HOME') + '/.config/MangoHud/MangoHud.conf';
 
-  Process.Executable := '/bin/bash';
+  Process.Executable := 'sh';
   Process.Parameters.Add('-c');
-  Process.Parameters.Add('cat ' +  CaminhoArquivo + ' | grep ' + Parametro);
+  Process.Parameters.Add('grep ''' + Parametro + ''' ' + CaminhoArquivo);
   Process.Options := [poUsePipes];
   Process.Execute;
 


### PR DESCRIPTION
Fixes #167 

This change puts the grep regex in single quotes, preventing flags like `-r` in the regex from being interpreted by grep. 

I also dropped the usage of cat, there is no need to do `cat | grep` since you can also tell the path to the file to grep directly (and this goes with most other coreutils as well). 

This is what goverlay sends to `sh` now ![image](https://github.com/user-attachments/assets/f28b8221-9003-49f6-8ef5-00dc9fd0c1d5)

Also removed hardcoded path to `/bin/bash` and instead calls `sh` in PATH like it normally does in other places.

And made a small fix in the CI where if the CI is ran on a branch it would delete the nightly release when it shouldn't 