### PR TITLE
bump dwarfs block size

### DIFF
--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -64,7 +64,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S25 -B32 \
+	--compression zstd:level=22 -S26 -B32 \
 	--header uruntime \
 	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 


### PR DESCRIPTION
Saves a wooping 0.7 MiB of the final size of the appimage xd 

The reason this wasn't done before was because it had a cost in the launch time of the appimage, now that was [fixed](https://github.com/pkgforge-dev/Citron-AppImage/pull/30) and this also slightly lower the ram usage as well, so it is worth it 👀

