### PR TITLE
Optimize size of appimage, make dedicated script for dependencies, prepare CI for `aarch64` builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -19,9 +19,9 @@ jobs:
           - runs-on: ubuntu-latest
             name: "Build goverlay appimage"
             arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            name: "Build goverlay appimage"
-            arch: aarch64
+#          - runs-on: ubuntu-24.04-arm
+#            name: "Build goverlay appimage"
+#            arch: aarch64
     container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -69,9 +69,9 @@ jobs:
         with:
           name: AppImage-x86_64
 
-      - uses: actions/download-artifact@v4.1.9
-        with:
-          name: AppImage-aarch64
+#      - uses: actions/download-artifact@v4.1.9
+#        with:
+#          name: AppImage-aarch64
 
       - name: Delete previous pre-release
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,9 +11,18 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
-    name: "build goverlay appimage"
-    runs-on: ubuntu-latest
-    container: artixlinux/artixlinux:latest
+    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            name: "Build goverlay appimage"
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: "Build goverlay appimage"
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -22,59 +31,8 @@ jobs:
 
       - name: Get dependencies
         run: |
-          sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-          pacman -Syu --noconfirm \
-            base-devel \
-            git \
-            cmake \
-            strace \
-            patchelf \
-            curl \
-            wget \
-            git \
-            artix-archlinux-support \
-            mesa \
-            mangohud \
-            xorg-server-xvfb \
-            vulkan-radeon \
-            vulkan-intel \
-            vulkan-nouveau
-
-          pacman-key --init && pacman-key --populate archlinux
-          printf "\n[extra]\nInclude = /etc/pacman.d/mirrorlist-arch\n" | tee -a /etc/pacman.conf
-          cat /etc/pacman.conf
-          sudo sed -i 's/NoExtract/#NoExtract/g' /etc/pacman.conf
-
-          pacman -Syu --noconfirm \
-            zsync \
-            qt6ct \
-            glu \
-            qt6pas \
-            vulkan-tools \
-            qt6-wayland \
-            lazarus \
-            pciutils
-
-      - name: Install debloated llvm-libs
-        run: |
-          LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
-          wget --retry-connrefused --tries=30 "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
-          pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
-          rm -f ./llvm-libs.pkg.tar.zst
-  
-      - name: Install iculess libxml2
-        run: |
-          LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
-          wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
-          pacman -U --noconfirm ./libxml2-iculess.pkg.tar.zst
-          rm -f ./libxml2-iculess.pkg.tar.zst
-
-      - name: Install iculess qt6-base
-        run: |
-          QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-x86_64.pkg.tar.zst"
-          wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base.pkg.tar.zst
-          pacman -U --noconfirm ./qt6-base.pkg.tar.zst
-          rm -f ./qt6-base.pkg.tar.zst
+          chmod +x ./appimage/get-dependencies.sh
+          ./appimage/get-dependencies.sh
 
       # Runs a set of commands using the runners shell
       - name: Build GOverlay
@@ -95,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: AppImage
+          name: AppImage-${{ matrix.arch }}
           path: "dist"
 
   release_nightly:
@@ -107,9 +65,13 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4.1.9
         with:
-          name: AppImage
+          name: AppImage-x86_64
+
+      - uses: actions/download-artifact@v4.1.9
+        with:
+          name: AppImage-aarch64
 
       - name: Delete previous pre-release
         if: ${{ github.ref_name == 'main' }}

--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+set -ex
+
+sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
+
+if [ "$(uname -m)" = 'x86_64' ]; then
+	PKG_TYPE='x86_64.pkg.tar.zst'
+else
+	PKG_TYPE='aarch64.pkg.tar.xz'
+fi
+
+LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
+QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-$PKG_TYPE"
+LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
+MESA_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/mesa-mini-$PKG_TYPE"
+
+echo "Installing build dependencies..."
+echo "---------------------------------------------------------------"
+pacman -Syu --noconfirm \
+	appstream \
+	base-devel \
+	cmake \
+	cmocka \
+	curl \
+	dbus \
+	fmt \
+	gcc-libs \
+	git \
+	glew \
+	glfw \
+	glslang \
+	glu \
+	hicolor-icon-theme \
+	lazarus \
+	libglvnd \
+	libx11 \
+	libxkbcommon \
+	mesa \
+	meson \
+	nlohmann-json \
+	patchelf \
+	pciutils \
+	python \
+	python-mako \
+	python-matplotlib \
+	python-numpy \
+	qt6ct \
+	qt6pas \
+	qt6-wayland \
+	strace \
+	vulkan-headers \
+	vulkan-icd-loader \
+	vulkan-nouveau \
+	vulkan-radeon \
+	vulkan-tools \
+	wayland \
+	wget \
+	xorg-server-xvfb \
+	zsync
+
+if [ "$(uname -m)" = 'x86_64' ]; then
+	pacman -Syu --noconfirm vulkan-intel
+else
+	pacman -Syu --noconfirm \
+		vulkan-freedreno vulkan-panfrost vulkan-broadcom
+fi
+
+
+echo "Building mangohud..."
+echo "---------------------------------------------------------------"
+sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
+mkdir -p /usr/local/bin
+cp /usr/bin/makepkg /usr/local/bin
+
+sed -i -e 's|-O2|-Os|' \
+	-e 's|MAKEFLAGS=.*|MAKEFLAGS="-j$(nproc)"|' \
+	-e 's|#MAKEFLAGS|MAKEFLAGS|' \
+	/etc/makepkg.conf
+
+cat /etc/makepkg.conf
+
+git clone https://gitlab.archlinux.org/archlinux/packaging/packages/mangohud.git ./mangohud
+( cd ./mangohud
+	sed -i -e "s|x86_64|$(uname -m)|" \
+		-e 's|-Dmangohudctl=true|-Dmangohudctl=true -Dwith_xnvctrl=disabled|' \
+		-e '/libxnvctrl/d' ./PKGBUILD
+	makepkg -f
+	ls -la .
+	pacman --noconfirm -U *.pkg.tar.*
+)
+rm -rf ./mangohud
+
+
+echo "Installing debloated pckages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$LLVM_URL"   -O  ./llvm.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$LIBXML_URL" -O  ./libxml2.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$QT6_URL"    -O  ./qt6-base.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$MESA_URL"   -O  ./mesa.pkg.tar.zst
+
+pacman -U --noconfirm ./*.pkg.tar.zst
+rm -f ./*.pkg.tar.zst
+
+
+echo "All done!"
+echo "---------------------------------------------------------------"

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -9,6 +9,7 @@ export VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
+URUNTIME_LITE="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-lite-$ARCH"
 
 # Prepare AppDir
 mkdir -p ./AppDir
@@ -54,18 +55,19 @@ ln ./sharun ./AppRun
 # make appimage with uruntime
 cd ..
 wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime
-chmod +x ./uruntime
+wget --retry-connrefused --tries=30 "$URUNTIME_LITE" -O ./uruntime-lite
+chmod +x ./uruntime*
 
 # Add udpate info to runtime
 echo "Adding update information \"$UPINFO\" to runtime..."
-./uruntime --appimage-addupdinfo "$UPINFO"
+./uruntime-lite --appimage-addupdinfo "$UPINFO"
 
 echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
 	--compression zstd:level=22 -S26 -B8 \
-	--header uruntime \
+	--header uruntime-lite \
 	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 
 zsyncmake *.AppImage -u *.AppImage

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -64,7 +64,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S26 -B32 \
+	--compression zstd:level=22 -S26 -B8 \
 	--header uruntime \
 	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 


### PR DESCRIPTION
These changes make the AppImage 55 MiB now. 

Everything is also ready to start making `aarch64` builds, but there is a quite a small problem that Goverlay doesn't compile in aarch64 👀

https://github.com/Samueru-sama/goverlay/actions/runs/14600931939/job/40958623576

Once that gets fixed, the commented out lines in the `.yml` can be removed.