### PR TITLE
simplify deps installation, use mesa that does not link to llvm

### DIFF
--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -2,18 +2,7 @@
 
 set -ex
 
-sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-
-if [ "$(uname -m)" = 'x86_64' ]; then
-	PKG_TYPE='x86_64.pkg.tar.zst'
-else
-	PKG_TYPE='aarch64.pkg.tar.xz'
-fi
-
-LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
-QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-$PKG_TYPE"
-LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
-MESA_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/mesa-mini-$PKG_TYPE"
+EXTRA_PACKAGES="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
 
 echo "Installing build dependencies..."
 echo "---------------------------------------------------------------"
@@ -59,49 +48,8 @@ pacman -Syu --noconfirm \
 	xorg-server-xvfb \
 	zsync
 
-if [ "$(uname -m)" = 'x86_64' ]; then
-	pacman -Syu --noconfirm vulkan-intel
-else
-	pacman -Syu --noconfirm \
-		vulkan-freedreno vulkan-panfrost vulkan-broadcom
-fi
-
-
-echo "Building mangohud..."
+echo "Installing debloated packages..."
 echo "---------------------------------------------------------------"
-sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
-mkdir -p /usr/local/bin
-cp /usr/bin/makepkg /usr/local/bin
-
-sed -i -e 's|-O2|-Os|' \
-	-e 's|MAKEFLAGS=.*|MAKEFLAGS="-j$(nproc)"|' \
-	-e 's|#MAKEFLAGS|MAKEFLAGS|' \
-	/etc/makepkg.conf
-
-cat /etc/makepkg.conf
-
-git clone https://gitlab.archlinux.org/archlinux/packaging/packages/mangohud.git ./mangohud
-( cd ./mangohud
-	sed -i -e "s|x86_64|$(uname -m)|" \
-		-e 's|-Dmangohudctl=true|-Dmangohudctl=true -Dwith_xnvctrl=disabled|' \
-		-e '/libxnvctrl/d' ./PKGBUILD
-	makepkg -f
-	ls -la .
-	pacman --noconfirm -U *.pkg.tar.*
-)
-rm -rf ./mangohud
-
-
-echo "Installing debloated pckages..."
-echo "---------------------------------------------------------------"
-wget --retry-connrefused --tries=30 "$LLVM_URL"   -O  ./llvm.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$LIBXML_URL" -O  ./libxml2.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$QT6_URL"    -O  ./qt6-base.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$MESA_URL"   -O  ./mesa.pkg.tar.zst
-
-pacman -U --noconfirm ./*.pkg.tar.zst
-rm -f ./*.pkg.tar.zst
-
-
-echo "All done!"
-echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
+chmod +x ./get-debloated-pkgs.sh
+./get-debloated-pkgs.sh --add-common mangohud-mini


### PR DESCRIPTION
with https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/28969 it became possible to build mesa without linking to llvm. 

As result the AppImage is now much smaller at 44 MiB.

NOTE: This change means that support for the AMD HD6000 series gpus and older is removed, those gpus are 15 years old though and I don't think anyone is actually running games with them anymore. 