### PR TITLE
simplify AppImage deployment

### DIFF
--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -53,3 +53,13 @@ echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
 chmod +x ./get-debloated-pkgs.sh
 ./get-debloated-pkgs.sh --add-common mangohud-mini
+
+echo "Building pascube..."
+echo "---------------------------------------------------------------"
+sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
+git clone --depth 1 https://github.com/benjamimgois/pascube ./pascube && (
+	cd ./pascube
+	makepkg -fs --noconfirm
+	ls -la .
+	pacman --noconfirm -U ./*.pkg.tar.*
+)

--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -54,12 +54,12 @@ wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
 chmod +x ./get-debloated-pkgs.sh
 ./get-debloated-pkgs.sh --add-common mangohud-mini
 
-echo "Building pascube..."
-echo "---------------------------------------------------------------"
-sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
-git clone --depth 1 https://github.com/benjamimgois/pascube ./pascube && (
-	cd ./pascube
-	makepkg -fs --noconfirm
-	ls -la .
-	pacman --noconfirm -U ./*.pkg.tar.*
-)
+#echo "Building pascube..."
+#echo "---------------------------------------------------------------"
+#sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
+#git clone --depth 1 https://github.com/benjamimgois/pascube ./pascube && (
+#	cd ./pascube
+#	makepkg -fs --noconfirm
+#	ls -la .
+#	pacman --noconfirm -U ./*.pkg.tar.*
+#)

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -8,15 +8,15 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 export VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
-URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
-URUNTIME_LITE="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-lite-$ARCH"
+URUNTIME="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/uruntime2appimage.sh"
+
+export DESKTOP=/usr/share/applications/io.github.benjamimgois.goverlay.desktop
+export ICON=/usr/share/icons/hicolor/256x256/apps/goverlay.png
+export OUTNAME=GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
 
 # Prepare AppDir
 mkdir -p ./AppDir
 cd ./AppDir
-cp /usr/share/applications/io.github.benjamimgois.goverlay.desktop ./
-cp /usr/share/icons/hicolor/256x256/apps/goverlay.png ./
-cp /usr/share/icons/hicolor/256x256/apps/goverlay.png ./.DirIcon
 
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
@@ -54,21 +54,6 @@ ln ./sharun ./AppRun
 
 # make appimage with uruntime
 cd ..
-wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime
-wget --retry-connrefused --tries=30 "$URUNTIME_LITE" -O ./uruntime-lite
-chmod +x ./uruntime*
-
-# Add udpate info to runtime
-echo "Adding update information \"$UPINFO\" to runtime..."
-./uruntime-lite --appimage-addupdinfo "$UPINFO"
-
-echo "Generating AppImage..."
-./uruntime --appimage-mkdwarfs -f \
-	--set-owner 0 --set-group 0 \
-	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S26 -B8 \
-	--header uruntime-lite \
-	-i ./AppDir -o GOverlay-"$VERSION"-anylinux-"$ARCH".AppImage
-
-zsyncmake *.AppImage -u *.AppImage
-echo "All Done!"
+wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime2appimage
+chmod +x ./uruntime2appimage
+./uruntime2appimage

--- a/appimage/goverlay-appimage.sh
+++ b/appimage/goverlay-appimage.sh
@@ -24,9 +24,11 @@ chmod +x ./lib4bin
 xvfb-run -a -- ./lib4bin -p -v -e -s -k \
 	/usr/lib/goverlay \
 	/usr/lib/mangohud/* \
+	/usr/lib/libvkbasalt.so* \
 	/usr/bin/vkcube \
 	/usr/bin/vkcube-wayland \
 	/usr/bin/lspci \
+	/usr/bin/mangohud \
 	/usr/lib/qt6/plugins/iconengines/* \
 	/usr/lib/qt6/plugins/imageformats/* \
 	/usr/lib/qt6/plugins/platforms/* \
@@ -39,15 +41,11 @@ xvfb-run -a -- ./lib4bin -p -v -e -s -k \
 cp -rv /usr/share/vulkan/implicit_layer.d ./share/vulkan
 sed -i 's|/usr/lib/mangohud/||' ./share/vulkan/implicit_layer.d/*
 
-echo 'MANGOHUD=1' > ./.env
-echo 'libMangoHud_shim.so' > ./.preload
+# remove full lib path from mangohud
+sed -i 's|/usr/.*/libMangoHud_shim.so|libMangoHud_shim.so|' ./bin/mangohud
 
-# Goverlay is also going to run sh -c mangohud vkcube so we need to wrap this
-echo '#!/bin/sh
-CURRENTDIR="$(dirname "$(readlink -f "$0")")"
-shift
-"$CURRENTDIR"/vkcube "$@"' > ./bin/mangohud
-chmod +x ./bin/mangohud
+# sharun does not allow LD_PRELOAD by default
+sed -i '1a\export SHARUN_ALLOW_LD_PRELOAD=1' ./bin/mangohud
 
 ln ./sharun ./AppRun
 ./sharun -g

--- a/gfxlaunch.pas
+++ b/gfxlaunch.pas
@@ -53,7 +53,7 @@ begin
   else
   begin
     // Método para driver Mesa
-    Cmd := 'MESA_LOADER_DRIVER_OVERRIDE=zink mangohud ' +
+    Cmd := 'LIBGL_KOPPER_DRI2=1 MESA_LOADER_DRIVER_OVERRIDE=zink mangohud ' +
            'QT_QPA_PLATFORM=xcb pascube &';
   end;
 


### PR DESCRIPTION
I'm not able to build `pascube` because the PKGBUILD fails with a weird error: https://github.com/Samueru-sama/goverlay/actions/runs/18294408292/job/52089337773#step:4:1235

But anyways, all that is left is getting `pascube` to build and bundle it. 

I no longer make a hacky wrapper over `mangohud`, instead I bundle it and do the needed changes so that it works inside the AppImage. 

Artifact: https://github.com/Samueru-sama/goverlay/actions/runs/18294509039

This also means that Goverlay should be able to launch `pascube` on its own if the host has it installed but it can't for some reason, I get this error: 

<img width="384" height="152" alt="image" src="https://github.com/user-attachments/assets/19f9650b-8877-4d9d-ad0c-05be8827f167" />

`vkcube` and everything else still works. 

