### PR TITLE
remove `qt6-wayland`

### DIFF
--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -32,7 +32,6 @@ pacman -Syu --noconfirm \
 	python-numpy \
 	qt6ct \
 	qt6pas \
-	qt6-wayland \
 	vulkan-tools \
 	wayland \
 	wget \


### PR DESCRIPTION
this hasn't been needed for a while, `qt6-base` provides the wayland client libs now (which is a dependency of `qt6pas`)

See: https://archlinux.org/todo/qt6-wayland-dependency-cleanup/