### PR TITLE
fix fps cap offset calculation

### DIFF
--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -2965,7 +2965,7 @@ begin
       begin
         if fpslimcheckgroup.Checked[i] then
         begin
-          SelectedValues.Add(IntToStr(StrToIntDef(fpslimcheckgroup.Items[i], 0) - offsetSpinedit.Value));
+          SelectedValues.Add(IntToStr(StrToIntDef(fpslimcheckgroup.Items[i], 0) + offsetSpinedit.Value));
           if StrToIntDef(fpslimcheckgroup.Items[i], 0) > MaxFPS then
             MaxFPS := StrToIntDef(fpslimcheckgroup.Items[i], 0);
         end;


### PR DESCRIPTION
the value is already negative so subtracting actually increases the fps cap