### PR TITLE
fix: sync original_dlls array in fgmod with fgmod-uninstaller to prevent file loss

### DIFF
--- a/data/fgmod/fgmod
+++ b/data/fgmod/fgmod
@@ -110,7 +110,7 @@ logger -t fgmod "📄 Preserve INI: $preserve_ini"
 rm -f "$exe_folder_path"/{dxgi.dll,winmm.dll,nvngx.dll,_nvngx.dll,nvngx-wrapper.dll,dlss-enabler.dll,OptiScaler.dll}
 
 # === Optional: Backup Original DLLs ===
-original_dlls=("d3dcompiler_47.dll" "amd_fidelityfx_dx12.dll" "amd_fidelityfx_framegeneration_dx12.dll" "amd_fidelityfx_upscaler_dx12.dll" "amd_fidelityfx_vk.dll")
+original_dlls=("d3dcompiler_47.dll" "amd_fidelityfx_dx12.dll" "amd_fidelityfx_framegeneration_dx12.dll" "amd_fidelityfx_upscaler_dx12.dll" "amd_fidelityfx_vk.dll" "libxess.dll" "libxess_dx11.dll" "libxess_fg.dll" "libxell.dll")
 for dll in "${original_dlls[@]}"; do
   [[ -f "$exe_folder_path/$dll" && ! -f "$exe_folder_path/$dll.b" ]] && mv -f "$exe_folder_path/$dll" "$exe_folder_path/$dll.b"
 done


### PR DESCRIPTION
## Summary
Syncs the original_dlls array with the uninstaller to prevent permanent file loss during installation.

## Changes
- Added missing DLLs (`libxess.dll`, `libxess_dx11.dll`, `libxess_fg.dll`, `libxell.dll`) to the backup array.
- This ensures these files are renamed to .b before being replaced, matching the cleanup logic in the uninstaller.