### PR TITLE
fix(bgmod): copy bgmod with default permissions

### DIFF
--- a/bgmod_resources.pas
+++ b/bgmod_resources.pas
@@ -207,7 +207,7 @@ begin
   try
     Proc.Executable := 'sh';
     Proc.Parameters.Add('-c');
-    Proc.Parameters.Add('cp -rf ' + QuotedStr(IncludeTrailingPathDelimiter(SourceDir) + '.') +
+    Proc.Parameters.Add('cp -rf --no-preserve=mode ' + QuotedStr(IncludeTrailingPathDelimiter(SourceDir) + '.') +
                         ' ' + QuotedStr(OriginalPath) + ' 2>/dev/null');
     Proc.Options := [poWaitOnExit];
     Proc.Execute;


### PR DESCRIPTION
This is the patch I introduced in https://github.com/NixOS/nixpkgs/pull/532126. Without it, it will end up copying what's in the nix store, a read-only filesystem, without resetting those permissions. It causes the program to crash when applying the overlay.