### PR TITLE
Correct vkSumi link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ An uninstaller binary (`bgmod-uninstaller`) cleanly removes wrapper files and re
 ### Optional / Used by specific features
 
 - [**`vkBasalt`**](https://github.com/DadSchoorse/vkBasalt) — Vulkan post-processing effects
-- [**`vksumi`**](https://github.com/benjamimgois/vksumi) *(optional but recommended)* — Alternative Vulkan post-processor with 15 tunable parameters
+- [**`vksumi`**](https://github.com/reakjra/vkSumi) *(optional but recommended)* — Alternative Vulkan post-processor with 15 tunable parameters
 - [**`zenergy`**](https://github.com/BoukeHaarsma23/zenergy) — Displays AMD CPU power metrics in MangoHud
 - [**`protontricks`**](https://github.com/Matoking/protontricks) — Proton prefix management (native builds only, disabled in Flatpak)
 


### PR DESCRIPTION
Hello. I have corrected the link to the [vkSumi](https://github.com/reakjra/vkSumi) Vulkan layer in README.md.