### PR TITLE
Do not derive the MangoHud config from button captions

### DIFF
--- a/mangohud_ui.pas
+++ b/mangohud_ui.pas
@@ -2903,6 +2903,8 @@ begin
     frametimetypeBitBtn.Caption := 'Curve';
     coreloadtypeBitBtn.ImageIndex := 6;
     coreloadtypeBitBtn.Caption := 'Percent';
+    gpuframesjouleBitBtn.Tag := 0;
+    cpuframesjouleBitBtn.Tag := 0;
     gpuframesjouleBitBtn.Caption := 'Frames / Joule';
     cpuframesjouleBitBtn.Caption := 'Frames / Joule';
     fpsavgBitBtn.ImageIndex := 9;
@@ -3036,6 +3038,8 @@ begin
       gpuefficiencyCheckBox.Checked := True
     else if SameText(ATrimmedLine, MANGO_FLAG_FLIP_EFFICIENCY) then
     begin
+      gpuframesjouleBitBtn.Tag := 1;
+      cpuframesjouleBitBtn.Tag := 1;
       gpuframesjouleBitBtn.Caption := 'Joules / Frame';
       cpuframesjouleBitBtn.Caption := 'Joules / Frame';
     end
@@ -3606,7 +3610,10 @@ begin
     Settings.GpuPower := gpupowerCheckBox.Checked;
     Settings.GpuPowerLimit := gpupowerlimitCheckBox.Checked;
     Settings.GpuEfficiency := gpuefficiencyCheckBox.Checked;
-    Settings.GpuFramesJouleCaption := gpuframesjouleBitBtn.Caption;
+    if gpuframesjouleBitBtn.Tag = 1 then
+      Settings.GpuFramesJouleCaption := MANGO_CAPTION_JOULES_PER_FRAME
+    else
+      Settings.GpuFramesJouleCaption := MANGO_CAPTION_FRAMES_PER_JOULE;
     Settings.GpuVoltage := gpuvoltageCheckBox.Checked;
     Settings.GpuThrottling := gputhrottlingCheckBox.Checked;
     Settings.GpuThrottlingGraph := gputhrottlinggraphCheckBox.Checked;
@@ -3618,7 +3625,10 @@ begin
     Settings.CpuText := cpunameEdit.Text;
     Settings.CpuAvgLoad := cpuavgloadCheckBox.Checked;
     Settings.CpuLoadCore := cpuloadcoreCheckBox.Checked;
-    Settings.CoreLoadTypeCaption := coreloadtypeBitBtn.Caption;
+    if coreloadtypeBitBtn.ImageIndex = 7 then
+      Settings.CoreLoadTypeCaption := MANGO_CAPTION_CORE_GRAPH
+    else
+      Settings.CoreLoadTypeCaption := MANGO_CAPTION_CORE_PERCENT;
     Settings.CpuLoadColorChecked := cpuloadcolorCheckBox.Checked;
     Settings.CpuLoadColors[0] := cpuload1ColorButton.ButtonColor;
     Settings.CpuLoadColors[1] := cpuload2ColorButton.ButtonColor;

--- a/overlay_config.pas
+++ b/overlay_config.pas
@@ -7,6 +7,14 @@ interface
 uses
   Classes, SysUtils, IniFiles, FileUtil, StrUtils, Types, Graphics, configfile, configmanager, overlay_utils, configkeys, bgmod_resources, optiscaler_update, systemdetector, apputils;
 
+const
+  // GpuFramesJouleCaption and CoreLoadTypeCaption are matched against these
+  // values below. They are the state the UI reports, not the text it shows.
+  MANGO_CAPTION_FRAMES_PER_JOULE = 'Frames / Joule';
+  MANGO_CAPTION_JOULES_PER_FRAME = 'Joules / Frame';
+  MANGO_CAPTION_CORE_PERCENT     = 'Percent';
+  MANGO_CAPTION_CORE_GRAPH       = 'Graph';
+
 type
   TVkBasaltSettings = record
     BasaltFolder: string;
@@ -1654,7 +1662,7 @@ begin
     AddIfTrue(Settings.GpuEfficiency, 'gpu_efficiency');
 
     // Flip efficiency (Joules / Frame mode)
-    if Settings.GpuFramesJouleCaption = 'Joules / Frame' then
+    if Settings.GpuFramesJouleCaption = MANGO_CAPTION_JOULES_PER_FRAME then
       ConfigLines.Add('flip_efficiency');
 
     // GPU voltage
@@ -1687,7 +1695,7 @@ begin
     AddIfTrue(Settings.CpuLoadCore, 'core_load');
 
     // Core load type (bars)
-    if Settings.CoreLoadTypeCaption = 'Graph' then
+    if Settings.CoreLoadTypeCaption = MANGO_CAPTION_CORE_GRAPH then
       ConfigLines.Add('core_bars');
 
     // CPU load color change

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -5086,9 +5086,12 @@ end;
 
 procedure Tgoverlayform.gpuframesjouleBitBtnClick(Sender: TObject);
 begin
-  // Toggle caption between 'Frames / Joule' and 'Joules / Frame'
-  // Both buttons share the same caption
-  if gpuframesjouleBitBtn.Caption = 'Frames / Joule' then
+  // Toggle between 'Frames / Joule' and 'Joules / Frame'. Both buttons share
+  // the same caption; the state lives in Tag so it does not depend on the
+  // text that happens to be on the button.
+  gpuframesjouleBitBtn.Tag := 1 - gpuframesjouleBitBtn.Tag;
+  cpuframesjouleBitBtn.Tag := gpuframesjouleBitBtn.Tag;
+  if gpuframesjouleBitBtn.Tag = 1 then
   begin
     gpuframesjouleBitBtn.Caption := 'Joules / Frame';
     cpuframesjouleBitBtn.Caption := 'Joules / Frame';


### PR DESCRIPTION
Whether `flip_efficiency` and `core_bars` end up in MangoHud.conf is decided by string-comparing what a button reads. `SaveMangoHudConfigCore` checks `GpuFramesJouleCaption` against `'Joules / Frame'` and `CoreLoadTypeCaption` against `'Graph'`, and the Frames/Joule button toggles itself by comparing its own caption as well. All the strings line up today, so the file comes out correct.

The catch is that those four captions can't be touched any more. Shorten `'Percent'` to `'%'`, or reword `'Graph'`, and `core_bars` quietly stops being written — no error, the option is simply gone from the config. This moves the decision to the state each button already carries (Tag for the efficiency toggle, the glyph index for the core load type) and puts the two values the writer matches on into named constants beside it, so the captions go back to being display text. The generated MangoHud.conf is identical before and after.

I ran into this while putting a translation together, where all four captions change at once and both options vanished together.
