### PR TITLE
Do not derive the MangoHud config from the remaining control captions

### DIFF
--- a/mangohud_ui.pas
+++ b/mangohud_ui.pas
@@ -3263,14 +3263,10 @@ begin
     begin
       if SameText(AValue, '0,1') then
       begin
-        for j := 0 to pcidevComboBox.Items.Count - 1 do
-        begin
-          if SameText(pcidevComboBox.Items[j], 'Use both GPUs') then
-          begin
-            pcidevComboBox.ItemIndex := j;
-            Break;
-          end;
-        end;
+        // Tag holds the 1-based position of the combined-GPU entry, 0 when
+        // the machine has a single GPU and the entry was never added.
+        if pcidevComboBox.Tag > 0 then
+          pcidevComboBox.ItemIndex := pcidevComboBox.Tag - 1;
       end
       else if TryStrToInt(AValue, IntValue) then
       begin
@@ -3540,7 +3536,9 @@ begin
 
     Settings.PciDevIndex := pcidevComboBox.ItemIndex;
     Settings.PciDevCount := pcidevComboBox.Items.Count;
-    if pcidevComboBox.ItemIndex <> -1 then
+    if (pcidevComboBox.Tag > 0) and (pcidevComboBox.ItemIndex = pcidevComboBox.Tag - 1) then
+      Settings.PciDevText := MANGO_PCIDEV_BOTH_GPUS
+    else if pcidevComboBox.ItemIndex <> -1 then
       Settings.PciDevText := pcidevComboBox.Items[pcidevComboBox.ItemIndex]
     else
       Settings.PciDevText := '';
@@ -3613,10 +3611,16 @@ begin
     Settings.Device := deviceCheckBox.Checked;
     Settings.Fps := fpsCheckBox.Checked;
     Settings.FpsAvg := fpsavgCheckBox.Checked;
-    Settings.FpsAvgCaption := fpsavgBitBtn.Caption;
+    if fpsavgBitBtn.ImageIndex = 9 then
+      Settings.FpsAvgCaption := MANGO_CAPTION_FPS_1PCT_LOW
+    else
+      Settings.FpsAvgCaption := MANGO_CAPTION_FPS_01PCT_LOW;
     Settings.FrametimeGraph := frametimegraphCheckBox.Checked;
     Settings.FrametimeGraphColor := frametimegraphColorButton.ButtonColor;
-    Settings.FrametimeTypeCaption := frametimetypeBitBtn.Caption;
+    if frametimetypeBitBtn.ImageIndex = 7 then
+      Settings.FrametimeTypeCaption := MANGO_CAPTION_FRAMETIME_HIST
+    else
+      Settings.FrametimeTypeCaption := MANGO_CAPTION_FRAMETIME_CURVE;
     Settings.FrameCount := framecountCheckBox.Checked;
     Settings.EngineVersion := engineversionCheckBox.Checked;
     Settings.EngineColor := engineColorButton.ButtonColor;

--- a/overlay_config.pas
+++ b/overlay_config.pas
@@ -8,12 +8,18 @@ uses
   Classes, SysUtils, IniFiles, FileUtil, StrUtils, Types, Graphics, configfile, configmanager, overlay_utils, configkeys, bgmod_resources, optiscaler_update, systemdetector, apputils;
 
 const
-  // GpuFramesJouleCaption and CoreLoadTypeCaption are matched against these
-  // values below. They are the state the UI reports, not the text it shows.
+  // GpuFramesJouleCaption, CoreLoadTypeCaption, FrametimeTypeCaption,
+  // FpsAvgCaption and PciDevText are matched against these values below.
+  // They are the state the UI reports, not the text it shows.
   MANGO_CAPTION_FRAMES_PER_JOULE = 'Frames / Joule';
   MANGO_CAPTION_JOULES_PER_FRAME = 'Joules / Frame';
   MANGO_CAPTION_CORE_PERCENT     = 'Percent';
   MANGO_CAPTION_CORE_GRAPH       = 'Graph';
+  MANGO_CAPTION_FRAMETIME_CURVE  = 'Curve';
+  MANGO_CAPTION_FRAMETIME_HIST   = 'Histogram';
+  MANGO_CAPTION_FPS_1PCT_LOW     = '1% low';
+  MANGO_CAPTION_FPS_01PCT_LOW    = '0.1% low';
+  MANGO_PCIDEV_BOTH_GPUS         = 'Use both GPUs';
 
 type
   TVkBasaltSettings = record
@@ -1600,7 +1606,7 @@ begin
     // PCI device and GPU List logic
     if Settings.PciDevIndex <> -1 then
     begin
-      if Settings.PciDevText = 'Use both GPUs' then
+      if Settings.PciDevText = MANGO_PCIDEV_BOTH_GPUS then
       begin
         ConfigLines.Add('gpu_list=0,1');
       end
@@ -1784,7 +1790,7 @@ begin
     // FPS metrics (avg)
     if Settings.FpsAvg then
     begin
-      if Settings.FpsAvgCaption = '1% low' then
+      if Settings.FpsAvgCaption = MANGO_CAPTION_FPS_1PCT_LOW then
         ConfigLines.Add('fps_metrics=avg,0.01')
       else
         ConfigLines.Add('fps_metrics=avg,0.001');
@@ -1798,7 +1804,7 @@ begin
     end;
 
     // Histogram
-    if Settings.FrametimeTypeCaption = 'Histogram' then
+    if Settings.FrametimeTypeCaption = MANGO_CAPTION_FRAMETIME_HIST then
       ConfigLines.Add('histogram');
 
     // Frame count

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -3254,10 +3254,14 @@ begin
     end; //while
 
 
-    // Add "Use both GPUs" option if multiple GPUs are detected
+    // Add "Use both GPUs" option if multiple GPUs are detected. Tag keeps the
+    // 1-based position of that entry (0 when it is absent), so the config
+    // logic can recognise it without matching on the item text.
+    pcidevCombobox.Tag := 0;
     if GPUNUMBER > 1 then
     begin
       pcidevCombobox.Items.Add('Use both GPUs');
+      pcidevCombobox.Tag := pcidevCombobox.Items.Count;
       GPUDESC.Add('All GPUs');
     end;
 


### PR DESCRIPTION
Follow-up to #374, which fixed the same class of bug for the efficiency and
core load buttons. Three more places still read UI text.

SaveMangoHudConfigCore decides whether to write `gpu_list=0,1` by comparing
PciDevText against 'Use both GPUs', whether to write `histogram` by comparing
FrametimeTypeCaption against 'Histogram', and which `fps_metrics` variant to
write by comparing FpsAvgCaption against '1% low'. All three values are taken
straight from the caption a control happens to show. The GPU one also runs in
reverse: loading a config searches the combobox for an item whose text is
'Use both GPUs'.

The strings match today, so the file comes out right. But the config output --
and, for the GPU case, config loading too -- is tied to UI text. Reword any of
those four labels and MangoHud silently gets a different file: `gpu_list` starts
naming a GPU index that does not exist, `histogram` stops being written, and the
FPS metric flips to the other variant.

The state each control already carries decides what is stored now: ImageIndex
for the two toggle buttons (they already switch on it, only the value handed to
the writer came from the caption), and Tag on the PCI combobox, which records
the 1-based position of the combined-GPU entry so both saving and loading can
find it without matching on text. The values the writer matches on join the
named constants added in #374, and the captions go back to being display text.

Behaviour is unchanged. Generated MangoHud.conf is byte-for-byte identical
across the full matrix -- each PCI entry, histogram/curve, 1% low/0.1% low --
including the save -> reload -> save cycle. The existing test suite passes
unmodified.
