### PR TITLE
Fix the Default build mode failing with Duplicate identifier "CMEM"

### DIFF
--- a/goverlay.lpi
+++ b/goverlay.lpi
@@ -169,7 +169,6 @@
     <Linking>
       <Debugging>
         <DebugInfoType Value="dsDwarf3"/>
-        <UseValgrind Value="True"/>
         <UseExternalDbgSyms Value="True"/>
       </Debugging>
       <Options>


### PR DESCRIPTION
`lazbuild goverlay.lpi` fails out of the box:

```
goverlay.lpr(7,7) Error: (5002) Duplicate identifier "CMEM"
goverlay.lpr(11,54) Error: (5002) Duplicate identifier "CMEM"
Fatal: (10026) There were 2 errors compiling module, stopping
```

The Default build mode inherits the project-wide compiler options, which set
`UseValgrind`. That flag makes FPC pass `-gv`, which links the Valgrind-compatible
heap manager -- and `cmem` is already listed explicitly in `goverlay.lpr` for UNIX.
The two collide and the build stops before it starts.

The Release mode defines its own compiler options and does not inherit the flag,
which is why `make` keeps working: the Makefile builds with `--bm=Release`. So the
breakage only hits someone who opens the project in the IDE and presses build, or
runs `lazbuild` without arguments -- which is the first thing a new contributor does.

Dropping `UseValgrind` from the shared options fixes it. `cmem` stays where it is,
so heap behaviour is unchanged; anyone who actually wants a Valgrind run can enable
the flag in their own build mode.

Verified on Lazarus 4.8 / FPC, Qt6 widgetset:

| | before | after |
|---|---|---|
| `lazbuild goverlay.lpi` (Default) | exit 2, Duplicate identifier "CMEM" | exit 0, binary produced |
| `lazbuild --bm=Release goverlay.lpi` | exit 0 | exit 0 |
