### PR TITLE
fix: stop deriving behaviour from control captions and status text

### DIFF
--- a/apputils.pas
+++ b/apputils.pas
@@ -420,61 +420,61 @@ begin
   begin
     if not FileExists('/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/libMangoHud.so') and
        not FileExists('/usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu/libMangoHud.so') then
-      Missing.Add('MangoHud runtime 25.08');
+      Missing.Add(DEP_MANGOHUD_RUNTIME);
     if not FileExists('/usr/lib/extensions/vulkan/vkBasalt/lib/x86_64-linux-gnu/vkbasalt/libvkbasalt.so') and
        not FileExists('/usr/lib/extensions/vulkan/vkBasalt/lib/i386-linux-gnu/vkbasalt/libvkbasalt.so') then
-      Missing.Add('vkBasalt runtime 25.08');
+      Missing.Add(DEP_VKBASALT_RUNTIME);
     if not FileExists('/usr/lib/extensions/vulkan/vkSumi/lib/x86_64-linux-gnu/libVkLayer_vksumi.so') and
        not FileExists('/usr/lib/extensions/vulkan/vkSumi/lib/i386-linux-gnu/libVkLayer_vksumi.so') then
-      Missing.Add('vkSumi runtime');
+      Missing.Add(DEP_VKSUMI_RUNTIME);
   end
   else
   begin
     if not IsCommandAvailable('mangohud') then
-      Missing.Add('mangohud');
+      Missing.Add(DEP_MANGOHUD);
     if not FileExists('/usr/share/vulkan/implicit_layer.d/vkBasalt.json') and
        not FileExists('/etc/vulkan/implicit_layer.d/vkBasalt.json') and
        not IsLibraryAvailable('libvkbasalt') then
-      Missing.Add('vkbasalt');
+      Missing.Add(DEP_VKBASALT);
 
     // vulkan-low-latency-layer: check Vulkan layer JSON then fall back to library scan
     if not FileExists('/usr/share/vulkan/implicit_layer.d/low_latency_layer.json') and
        not FileExists('/etc/vulkan/implicit_layer.d/low_latency_layer.json') and
        not FileExists(GetUserDir + '.local/share/vulkan/implicit_layer.d/low_latency_layer.json') and
        not IsLibraryAvailable('libVkLayer_KORTHOS_LowLatency') then
-      Missing.Add('vulkan-low-latency-layer');
+      Missing.Add(DEP_LOW_LATENCY_LAYER);
   end;
 
 
   if not IsCommandAvailable('7z') then
-    Missing.Add('p7zip');
+    Missing.Add(DEP_P7ZIP);
   if not IsCommandAvailable('curl') then
-    Missing.Add('curl');
+    Missing.Add(DEP_CURL);
   if not IsCommandAvailable('git') then
-    Missing.Add('git');
+    Missing.Add(DEP_GIT);
 
   if not IsRunningInFlatpak then
   begin
     if not IsCommandAvailable('protontricks') then
-      Missing.Add('protontricks');
+      Missing.Add(DEP_PROTONTRICKS);
   end;
 
   if not IsRunningInFlatpak then
   begin
     if not IsCommandAvailable('gamemoderun') then
-      Missing.Add('gamemode');
+      Missing.Add(DEP_GAMEMODE);
   end;
 
   {$IFDEF LCLqt6}
   if not IsLibraryAvailable('libQt6Pas') then
-    Missing.Add('libqt6pas');
+    Missing.Add(DEP_LIBQT6PAS);
   {$ELSE}
   if not IsLibraryAvailable('libQt5Pas') then
-    Missing.Add('libqt5pas');
+    Missing.Add(DEP_LIBQT5PAS);
   {$ENDIF}
 
   if not IsNerdFontInstalled then
-    Missing.Add('nerdfonts');
+    Missing.Add(DEP_NERDFONTS);
 
   Result := Missing.Count = 0;
 end;

--- a/constants.pas
+++ b/constants.pas
@@ -15,6 +15,29 @@ const
   APP_AUTHOR = 'Benjamim Gois';
 
   // ============================================================================
+  // DEPENDENCY LIST ENTRIES
+  // ============================================================================
+  // Entries CheckDependencies puts into its Missing list. The list is shown to
+  // the user and searched by the Home tab and the Tweaks tab, so the producer
+  // and every consumer must name an entry through the same constant instead of
+  // repeating the wording.
+  DEP_MANGOHUD          = 'mangohud';
+  DEP_MANGOHUD_RUNTIME  = 'MangoHud runtime 25.08';
+  DEP_VKBASALT          = 'vkbasalt';
+  DEP_VKBASALT_RUNTIME  = 'vkBasalt runtime 25.08';
+  DEP_VKSUMI            = 'vksumi';
+  DEP_VKSUMI_RUNTIME    = 'vkSumi runtime';
+  DEP_LOW_LATENCY_LAYER = 'vulkan-low-latency-layer';
+  DEP_P7ZIP             = 'p7zip';
+  DEP_CURL              = 'curl';
+  DEP_GIT               = 'git';
+  DEP_PROTONTRICKS      = 'protontricks';
+  DEP_GAMEMODE          = 'gamemode';
+  DEP_LIBQT6PAS         = 'libqt6pas';
+  DEP_LIBQT5PAS         = 'libqt5pas';
+  DEP_NERDFONTS         = 'nerdfonts';
+
+  // ============================================================================
   // GITHUB URLS
   // ============================================================================
 

--- a/games_tab.pas
+++ b/games_tab.pas
@@ -2949,10 +2949,10 @@ begin
   with FForm do
   begin
   if not (Sender is TMenuItem) then Exit;
-  FolderPath := TMenuItem(Sender).Caption;
+  // ShowRemoveFoldersMenu stores the folder in Hint; the caption is the
+  // label the user reads and is not parsed back into a path.
+  FolderPath := TMenuItem(Sender).Hint;
   if FolderPath = '' then Exit;
-  if Copy(FolderPath, 1, 8) = 'Remove: ' then
-    FolderPath := Copy(FolderPath, 9, MaxInt);
 
   // Ask user if they want to remove that folder
   if MessageDlg('Remove non-Steam folder', 
@@ -3014,6 +3014,9 @@ begin
         
         SubItem := TMenuItem.Create(nil);
         SubItem.Caption := 'Remove: ' + FolderPath;
+        // The click handler removes this exact path. It reads it from here
+        // rather than from the caption, which is display text.
+        SubItem.Hint := FolderPath;
         SubItem.OnClick := @RemoveFolderMenuItemClick;
         FRemoveFoldersMenu.Items.Add(SubItem);
         Inc(AddedCount);

--- a/goverlay_system.pas
+++ b/goverlay_system.pas
@@ -378,69 +378,69 @@ begin
     // MangoHud extension
     if not FileExists('/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/libMangoHud.so') and
        not FileExists('/usr/lib/extensions/vulkan/MangoHud/lib/i386-linux-gnu/libMangoHud.so') then
-      Missing.Add('MangoHud runtime 25.08');
+      Missing.Add(DEP_MANGOHUD_RUNTIME);
 
     // vkBasalt extension
     if not FileExists('/usr/lib/extensions/vulkan/vkBasalt/lib/x86_64-linux-gnu/vkbasalt/libvkbasalt.so') and
        not FileExists('/usr/lib/extensions/vulkan/vkBasalt/lib/i386-linux-gnu/vkbasalt/libvkbasalt.so') then
-      Missing.Add('vkBasalt runtime 25.08');
+      Missing.Add(DEP_VKBASALT_RUNTIME);
 
     // vkSumi extension
     if not FileExists('/usr/lib/extensions/vulkan/vkSumi/lib/x86_64-linux-gnu/libVkLayer_vksumi.so') and
        not FileExists('/usr/lib/extensions/vulkan/vkSumi/lib/i386-linux-gnu/libVkLayer_vksumi.so') then
-      Missing.Add('vkSumi runtime');
+      Missing.Add(DEP_VKSUMI_RUNTIME);
   end
   else
   begin
     // Native: mangohud binary (all distros install it to PATH)
     if not IsCommandAvailable('mangohud') then
-      Missing.Add('mangohud');
+      Missing.Add(DEP_MANGOHUD);
 
     // vkBasalt: check Vulkan layer JSON (distro-agnostic) then fall back to library scan
     if not FileExists('/usr/share/vulkan/implicit_layer.d/vkBasalt.json') and
        not FileExists('/etc/vulkan/implicit_layer.d/vkBasalt.json') and
        not IsLibraryAvailable('libvkbasalt') then
-      Missing.Add('vkbasalt');
+      Missing.Add(DEP_VKBASALT);
 
     // vkSumi: check Vulkan layer JSON then fall back to library scan
     if not FileExists('/usr/share/vulkan/implicit_layer.d/vksumi.json') and
        not FileExists('/etc/vulkan/implicit_layer.d/vksumi.json') and
        not FileExists(GetUserDir + '.local/share/vulkan/implicit_layer.d/vksumi.json') and
        not IsLibraryAvailable('libVkLayer_vksumi') then
-      Missing.Add('vksumi');
+      Missing.Add(DEP_VKSUMI);
 
     // vulkan-low-latency-layer: check Vulkan layer JSON then fall back to library scan
     if not FileExists('/usr/share/vulkan/implicit_layer.d/low_latency_layer.json') and
        not FileExists('/etc/vulkan/implicit_layer.d/low_latency_layer.json') and
        not FileExists(GetUserDir + '.local/share/vulkan/implicit_layer.d/low_latency_layer.json') and
        not IsLibraryAvailable('libVkLayer_KORTHOS_LowLatency') then
-      Missing.Add('vulkan-low-latency-layer');
+      Missing.Add(DEP_LOW_LATENCY_LAYER);
   end;
 
 
 
   // check if 7z is available
   if not IsCommandAvailable('7z') then
-    Missing.Add('p7zip');
+    Missing.Add(DEP_P7ZIP);
 
   // check if curl is available
   if not IsCommandAvailable('curl') then
-    Missing.Add('curl');
+    Missing.Add(DEP_CURL);
 
   // check if git is available
   if not IsCommandAvailable('git') then
-    Missing.Add('git');
+    Missing.Add(DEP_GIT);
 
   // check if Nerd Font is available
   if not IsNerdFontInstalled then
-    Missing.Add('nerdfonts');
+    Missing.Add(DEP_NERDFONTS);
 
   // check if protontricks is available
   // Skip check in Flatpak since we fallback to com.github.Matoking.protontricks Flatpak
   if not IsRunningInFlatpak then
   begin
     if not IsCommandAvailable('protontricks') then
-      Missing.Add('protontricks');
+      Missing.Add(DEP_PROTONTRICKS);
   end;
 
   // check if gamemoderun is available (required for GameMode feature in Tweaks tab)
@@ -448,7 +448,7 @@ begin
   if not IsRunningInFlatpak then
   begin
     if not IsCommandAvailable('gamemoderun') then
-      Missing.Add('gamemode');
+      Missing.Add(DEP_GAMEMODE);
   end;
 
   // Check for libqt6pas (Qt6 Pascal bindings — required for Goverlay GUI).
@@ -456,10 +456,10 @@ begin
   // IsLibraryAvailable checks both via case-insensitive ldconfig + path scan.
   {$IFDEF LCLqt6}
   if not IsLibraryAvailable('libQt6Pas') then
-    Missing.Add('libqt6pas');
+    Missing.Add(DEP_LIBQT6PAS);
   {$ELSE}
   if not IsLibraryAvailable('libQt5Pas') then
-    Missing.Add('libqt5pas');
+    Missing.Add(DEP_LIBQT5PAS);
   {$ENDIF}
 
   // check if zenergy module is available

--- a/home_tab.pas
+++ b/home_tab.pas
@@ -428,14 +428,14 @@ begin
 
     CheckDependencies(Missing);
     try
-      MangoOK := (Missing.IndexOf('mangohud') < 0) and
-                 (Missing.IndexOf('MangoHud runtime 25.08') < 0);
-      VkOK    := (Missing.IndexOf('vkbasalt') < 0) and
-                 (Missing.IndexOf('vkBasalt runtime 25.08') < 0);
+      MangoOK := (Missing.IndexOf(DEP_MANGOHUD) < 0) and
+                 (Missing.IndexOf(DEP_MANGOHUD_RUNTIME) < 0);
+      VkOK    := (Missing.IndexOf(DEP_VKBASALT) < 0) and
+                 (Missing.IndexOf(DEP_VKBASALT_RUNTIME) < 0);
       OptiOK  := FForm.IsOptiScalerInstalled;
       DlssOK  := Self.IsDlssEnablerInstalled;
-      SumiOK  := (Missing.IndexOf('vksumi') < 0) and
-                 (Missing.IndexOf('vkSumi runtime') < 0);
+      SumiOK  := (Missing.IndexOf(DEP_VKSUMI) < 0) and
+                 (Missing.IndexOf(DEP_VKSUMI_RUNTIME) < 0);
     finally
       Missing.Free;
     end;
@@ -523,7 +523,8 @@ procedure THomeTabHelper.RefreshHomeDeps;
 const
   {$IFDEF LCLqt6}
   DEP_KEYS: array[0..6] of string = (
-    'p7zip', 'curl', 'git', 'gamemode', 'libqt6pas', 'nerdfonts', 'vulkan-low-latency-layer');
+    DEP_P7ZIP, DEP_CURL, DEP_GIT, DEP_GAMEMODE, DEP_LIBQT6PAS, DEP_NERDFONTS,
+    DEP_LOW_LATENCY_LAYER);
   DEP_DISPLAY: array[0..6] of string = (
     '7z (p7zip)', 'curl', 'git', 'gamemode', 'qt6pas', 'Nerd Fonts', 'Korthos low latency');
   DEP_HINTS: array[0..6] of string = (
@@ -536,7 +537,8 @@ const
     'Vulkan Low Latency layer — latency reduction layer');
   {$ELSE}
   DEP_KEYS: array[0..6] of string = (
-    'p7zip', 'curl', 'git', 'gamemode', 'libqt5pas', 'nerdfonts', 'vulkan-low-latency-layer');
+    DEP_P7ZIP, DEP_CURL, DEP_GIT, DEP_GAMEMODE, DEP_LIBQT5PAS, DEP_NERDFONTS,
+    DEP_LOW_LATENCY_LAYER);
   DEP_DISPLAY: array[0..6] of string = (
     '7z (p7zip)', 'curl', 'git', 'gamemode', 'qt5pas', 'Nerd Fonts', 'Korthos low latency');
   DEP_HINTS: array[0..6] of string = (

--- a/optiscaler_tab.pas
+++ b/optiscaler_tab.pas
@@ -776,7 +776,6 @@ const
   CLR_NONE   = $00666666;   // gray  — not installed
   PURPLE     = $BB99FF;
   CLR_UPDATE = $0044AAFF;   // blue highlight — update available
-  PREFIX_LEN = 17; // Length('Update Available ')
 var
   i: Integer;
   Ver, NewTag, VerCaption: string;
@@ -797,9 +796,9 @@ begin
 
             if optLabel2.Visible and (optLabel2.Caption <> '') then
             begin
-              NewTag := optLabel2.Caption;
-              if Pos('Update Available ', NewTag) = 1 then
-                NewTag := Copy(NewTag, PREFIX_LEN + 1, MaxInt);
+              // The update notice stores the bare tag in Hint; its caption is
+              // a sentence and must not be taken apart to recover the tag.
+              NewTag := optLabel2.Hint;
               if NewTag <> '' then
               begin
                 VerCaption := VerCaption + ' → ' + NewTag;

--- a/optiscaler_update.pas
+++ b/optiscaler_update.pas
@@ -266,7 +266,10 @@ begin
 
       if HasUpdate then
       begin
-        FOptiTab.FOptiLabel2.Caption := 'Update Available ' + FOptiTab.FormatDlssEnablerDisplayTag(FLatestOptiTag);
+        // Hint carries the bare tag for RefreshOsStatusDots; the caption is
+        // the sentence the user reads and is not parsed back.
+        FOptiTab.FOptiLabel2.Hint := FOptiTab.FormatDlssEnablerDisplayTag(FLatestOptiTag);
+        FOptiTab.FOptiLabel2.Caption := 'Update Available ' + FOptiTab.FOptiLabel2.Hint;
         FOptiTab.FOptiLabel2.Font.Color := clLime;
         FOptiTab.FOptiLabel2.Visible := True;
         if Assigned(FOptiTab.FUpdateBtn) then
@@ -306,6 +309,7 @@ begin
 
         if IsCrossChannel or (CompareVersions(NormLatest, NormCurrent) > 0) then
         begin
+          FOptiTab.FOptiLabel2.Hint := FLatestOptiTag;
           FOptiTab.FOptiLabel2.Caption := 'Update Available ' + FLatestOptiTag;
           FOptiTab.FOptiLabel2.Font.Color := clLime;
           FOptiTab.FOptiLabel2.Visible := True;
@@ -1805,6 +1809,7 @@ begin
 
   if Assigned(FOptiLabel2) then
   begin
+    FOptiLabel2.Hint := '';
     FOptiLabel2.Caption := 'Searching for updates...';
     FOptiLabel2.Font.Color := clAqua;
     FOptiLabel2.Visible := True;

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -3565,7 +3565,7 @@ begin
     end;
     
     // Disable gamemodeCheckBox if gamemode is missing
-    if Missing.IndexOf('gamemode') >= 0 then
+    if Missing.IndexOf(DEP_GAMEMODE) >= 0 then
     begin
       gamemodeCheckBox.Enabled := False;
       gamemodeCheckBox.Hint := 'GameMode is not installed - install gamemode package to enable this feature';

--- a/overlayunit.pas
+++ b/overlayunit.pas
@@ -4062,11 +4062,13 @@ begin
   // Category colour
   if aCol = 1 then
   begin
+    // Both sides of these comparisons come from TweakCategoryName, so the
+    // colouring follows the header text instead of being pinned to one wording.
     Cat := Grid.Cells[1, aRow];
-    if Cat = 'General'    then Grid.Canvas.Font.Color := $00E8E8E8;
-    if Cat = 'Graphics'   then Grid.Canvas.Font.Color := $00F0A860;
-    if Cat = 'Performance'then Grid.Canvas.Font.Color := $0040D8F0;
-    if Cat = 'Custom'     then Grid.Canvas.Font.Color := $00B0B0B0;
+    if Cat = TweakCategoryName(TWEAK_CAT_GENERAL)  then Grid.Canvas.Font.Color := $00E8E8E8;
+    if Cat = TweakCategoryName(TWEAK_CAT_GRAPHICS) then Grid.Canvas.Font.Color := $00F0A860;
+    if Cat = TweakCategoryName(TWEAK_CAT_PERF)     then Grid.Canvas.Font.Color := $0040D8F0;
+    if Cat = TweakCategoryName(TWEAK_CAT_CUSTOM)   then Grid.Canvas.Font.Color := $00B0B0B0;
   end;
 
   // Monospace for variable column
@@ -4185,7 +4187,7 @@ begin
           FTweaksGrid.Cells[0, i + 1] := '1'
         else
           FTweaksGrid.Cells[0, i + 1] := '0';
-        FTweaksGrid.Cells[1, i + 1] := TWEAK_ROWS[i].Category;
+        FTweaksGrid.Cells[1, i + 1] := TweakCategoryName(TWEAK_ROWS[i].Category);
         FTweaksGrid.Cells[2, i + 1] := TWEAK_ROWS[i].VarName;
         FTweaksGrid.Cells[3, i + 1] := TWEAK_ROWS[i].Description;
       end;
@@ -4610,7 +4612,7 @@ begin
     Row := FTweaksGrid.RowCount;
     FTweaksGrid.RowCount := Row + 1;
     FTweaksGrid.Cells[0, Row] := '1';         // checked by default
-    FTweaksGrid.Cells[1, Row] := 'Custom';
+    FTweaksGrid.Cells[1, Row] := TweakCategoryName(TWEAK_CAT_CUSTOM);
     FTweaksGrid.Cells[2, Row] := Val;
     FTweaksGrid.Cells[3, Row] := '';
   end;

--- a/systemdetector.pas
+++ b/systemdetector.pas
@@ -7,6 +7,13 @@ interface
 uses
   Classes, SysUtils, Process, StrUtils, FileUtil, IniFiles, Dialogs, configmanager;
 
+const
+  // Values of GOVERLAY_PACKAGE_TYPE, read by the launcher and by bgmod.
+  // They are identifiers, not the wording shown on the Home tab.
+  GOVERLAY_PKG_FLATPAK  = 'flatpak';
+  GOVERLAY_PKG_APPIMAGE = 'appimage';
+  GOVERLAY_PKG_NATIVE   = 'native';
+
 type
   /// <summary>
   /// GPU vendor types
@@ -159,7 +166,13 @@ function IsLibraryAvailable(const LibName: string): Boolean;
 function IsNerdFontInstalled: Boolean;
 
 /// <summary>
-/// Gets GOverlay installation type (Flatpak, AppImage, or Native)
+/// Gets the GOverlay packaging identifier used by the launcher scripts
+/// </summary>
+/// <returns>GOVERLAY_PKG_FLATPAK, GOVERLAY_PKG_APPIMAGE or GOVERLAY_PKG_NATIVE</returns>
+function GetGOverlayPackageType: string;
+
+/// <summary>
+/// Gets GOverlay installation type (Flatpak, AppImage, or Native) for display
 /// </summary>
 /// <returns>String indicating installation type</returns>
 function GetGOverlayInstallationType: string;
@@ -1198,24 +1211,32 @@ begin
   Result := RunCommand('sh', ['-c', 'fc-list | grep -qi "Nerd Font\|Symbols Nerd Font\|NerdFont"'], Output);
 end;
 
-function GetGOverlayInstallationType: string;
+function GetGOverlayPackageType: string;
 begin
   if IsRunningInFlatpak then
-    Result := 'Flatpak'
+    Result := GOVERLAY_PKG_FLATPAK
   else if GetEnvironmentVariable('APPIMAGE') <> '' then
+    Result := GOVERLAY_PKG_APPIMAGE
+  else
+    Result := GOVERLAY_PKG_NATIVE;
+end;
+
+function GetGOverlayInstallationType: string;
+var
+  PkgType: string;
+begin
+  PkgType := GetGOverlayPackageType;
+  if PkgType = GOVERLAY_PKG_FLATPAK then
+    Result := 'Flatpak'
+  else if PkgType = GOVERLAY_PKG_APPIMAGE then
     Result := 'Appimage'
   else
     Result := 'Native package';
 end;
 
 function GetGOverlayPackageEnv: string;
-var
-  PkgType: string;
 begin
-  PkgType := LowerCase(GetGOverlayInstallationType);
-  if PkgType = 'native package' then
-    PkgType := 'native';
-  Result := 'GOVERLAY_PACKAGE_TYPE="' + PkgType + '" ';
+  Result := 'GOVERLAY_PACKAGE_TYPE="' + GetGOverlayPackageType + '" ';
 end;
 
 function IsPasCubeAvailable: Boolean;

--- a/tweaks_md3.pas
+++ b/tweaks_md3.pas
@@ -10,43 +10,53 @@ uses
 type
   TTweakRow = record
     CheckBox: TCheckBox;
-    Category: string;
+    // Category is the identity of the group a row belongs to, not the text
+    // drawn for it. TweakCategoryName maps it to the header caption.
+    Category: Integer;
     VarName: string;
     Description: string;
   end;
 
 const
+  TWEAK_CAT_GENERAL  = 0;
+  TWEAK_CAT_GRAPHICS = 1;
+  TWEAK_CAT_PERF     = 2;
+  TWEAK_CAT_LATENCY  = 3;
+  // Custom rows are added by the user at run time; they are not part of
+  // TWEAK_ROWS but share the category column of the backing grid.
+  TWEAK_CAT_CUSTOM   = 4;
+
   TWEAK_ROW_COUNT = 29;
   TWEAK_ROWS: array[0..TWEAK_ROW_COUNT - 1] of TTweakRow = (
-    (CheckBox: nil; Category: 'General';    VarName: 'SteamDeck=1';                      Description: 'Simulate Steam Deck hardware'),
-    (CheckBox: nil; Category: 'Performance'; VarName: '#gamemode';                        Description: 'Use Feral Gamemode set of optimisations'),
-    (CheckBox: nil; Category: 'General';    VarName: 'PROTON_ENABLE_HDR=1';              Description: 'Enable HDR'),
-    (CheckBox: nil; Category: 'General';    VarName: 'PROTON_ENABLE_WAYLAND=1';          Description: 'Enable Wayland'),
-    (CheckBox: nil; Category: 'General';    VarName: 'PROTON_LOG=1';                     Description: 'Active Proton Logs'),
-    (CheckBox: nil; Category: 'General';    VarName: 'PROTON_USE_SDL=1';                 Description: 'Use SDL input instead steam input'),
-    (CheckBox: nil; Category: 'General';    VarName: 'OBS_VKCAPTURE=1';                  Description: 'Activate Vulkan capture for OBS Studio'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'RADV_PERFTEST=rt,emulate_rt';      Description: 'Emulates Ray Tracing on GPUs without native support'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_HIDE_NVIDIA_GPU=1';         Description: 'Hide Nvidia GPU'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_ENABLE_NVAPI=1';            Description: 'Force enable NVAPI'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_USE_WINED3D=1';             Description: 'Use old WINED3D'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'MESA_LOADER_DRIVER_OVERRIDE=zink'; Description: 'Uses OpenGL over Vulkan translation (ZINK)'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'RADV_DEBUG=nofastclears';          Description: 'Disables fast clear optimization (AMD)'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_FSR4_UPGRADE=1';            Description: 'Automatically upgrade FSR to the latest version'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_DLSS_UPGRADE=1';            Description: 'Automatically upgrade DLSS to the latest version'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: 'PROTON_XESS_UPGRADE=1';            Description: 'Automatically upgrade XeSS to the latest version'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'PROTON_PRIORITY_HIGH=1';           Description: 'Higher priority for games'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'PROTON_USE_WOW64=1';               Description: 'Windows 64-bit compatibility'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'PROTON_FORCE_LARGE_ADDRESS_AWARE=1'; Description: 'Allows 32-bit games to use more than 2GB RAM'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'STAGING_SHARED_MEMORY=1';          Description: 'Memory optimization for AMD GPUs'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'PROTON_NO_NTSYNC=1';               Description: 'Disable NTSYNC'),
-    (CheckBox: nil; Category: 'Performance';VarName: 'PROTON_HEAP_DELAY_FREE=1';         Description: 'Delay in heap allocation (Wine)'),
-    (CheckBox: nil; Category: 'Graphics';   VarName: '#winedetectionenable=false';       Description: 'Enable RE Engine Ray Tracing workaround'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'LOW_LATENCY_LAYER=1';       Description: '[low_latency_layer] Expose to enable the layer'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'LOW_LATENCY_LAYER_REFLEX=1'; Description: '[low_latency_layer] Expose Reflex support (VK_NV_low_latency2) instead of AMD Anti-Lag 2'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'LOW_LATENCY_LAYER_SPOOF_NVIDIA=1'; Description: '[low_latency_layer] Report device as NVIDIA GPU (breaks FSR4 upgrade path)'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'DXVK_CONFIG="dxgi.hideAmdGpu = True"'; Description: '[low_latency_layer] Also hide AMD GPU, but it''s safer than SPOOF_NVIDIA'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'ENABLE_LAYER_MESA_ANTI_LAG=1';     Description: '[MESA] Enable AMD Anti-Lag 2'),
-    (CheckBox: nil; Category: 'Latency reduction'; VarName: 'PROTON_VKD3D_LOWLATENCY=1';      Description: '[proton-cachyos] low-latency frame pacing capabilities')
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'SteamDeck=1';                      Description: 'Simulate Steam Deck hardware'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF; VarName: '#gamemode';                        Description: 'Use Feral Gamemode set of optimisations'),
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'PROTON_ENABLE_HDR=1';              Description: 'Enable HDR'),
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'PROTON_ENABLE_WAYLAND=1';          Description: 'Enable Wayland'),
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'PROTON_LOG=1';                     Description: 'Active Proton Logs'),
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'PROTON_USE_SDL=1';                 Description: 'Use SDL input instead steam input'),
+    (CheckBox: nil; Category: TWEAK_CAT_GENERAL;    VarName: 'OBS_VKCAPTURE=1';                  Description: 'Activate Vulkan capture for OBS Studio'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'RADV_PERFTEST=rt,emulate_rt';      Description: 'Emulates Ray Tracing on GPUs without native support'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_HIDE_NVIDIA_GPU=1';         Description: 'Hide Nvidia GPU'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_ENABLE_NVAPI=1';            Description: 'Force enable NVAPI'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_USE_WINED3D=1';             Description: 'Use old WINED3D'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'MESA_LOADER_DRIVER_OVERRIDE=zink'; Description: 'Uses OpenGL over Vulkan translation (ZINK)'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'RADV_DEBUG=nofastclears';          Description: 'Disables fast clear optimization (AMD)'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_FSR4_UPGRADE=1';            Description: 'Automatically upgrade FSR to the latest version'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_DLSS_UPGRADE=1';            Description: 'Automatically upgrade DLSS to the latest version'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: 'PROTON_XESS_UPGRADE=1';            Description: 'Automatically upgrade XeSS to the latest version'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'PROTON_PRIORITY_HIGH=1';           Description: 'Higher priority for games'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'PROTON_USE_WOW64=1';               Description: 'Windows 64-bit compatibility'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'PROTON_FORCE_LARGE_ADDRESS_AWARE=1'; Description: 'Allows 32-bit games to use more than 2GB RAM'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'STAGING_SHARED_MEMORY=1';          Description: 'Memory optimization for AMD GPUs'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'PROTON_NO_NTSYNC=1';               Description: 'Disable NTSYNC'),
+    (CheckBox: nil; Category: TWEAK_CAT_PERF;VarName: 'PROTON_HEAP_DELAY_FREE=1';         Description: 'Delay in heap allocation (Wine)'),
+    (CheckBox: nil; Category: TWEAK_CAT_GRAPHICS;   VarName: '#winedetectionenable=false';       Description: 'Enable RE Engine Ray Tracing workaround'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'LOW_LATENCY_LAYER=1';       Description: '[low_latency_layer] Expose to enable the layer'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'LOW_LATENCY_LAYER_REFLEX=1'; Description: '[low_latency_layer] Expose Reflex support (VK_NV_low_latency2) instead of AMD Anti-Lag 2'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'LOW_LATENCY_LAYER_SPOOF_NVIDIA=1'; Description: '[low_latency_layer] Report device as NVIDIA GPU (breaks FSR4 upgrade path)'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'DXVK_CONFIG="dxgi.hideAmdGpu = True"'; Description: '[low_latency_layer] Also hide AMD GPU, but it''s safer than SPOOF_NVIDIA'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'ENABLE_LAYER_MESA_ANTI_LAG=1';     Description: '[MESA] Enable AMD Anti-Lag 2'),
+    (CheckBox: nil; Category: TWEAK_CAT_LATENCY; VarName: 'PROTON_VKD3D_LOWLATENCY=1';      Description: '[proton-cachyos] low-latency frame pacing capabilities')
   );
 
 type
@@ -71,8 +81,24 @@ type
   end;
 
 function GetTweakRowCheckBox(Form: Tgoverlayform; Index: Integer): TCheckBox;
+// Header caption for a TWEAK_CAT_* value. Display only: nothing branches on
+// the string it returns.
+function TweakCategoryName(ACategory: Integer): string;
 
 implementation
+
+function TweakCategoryName(ACategory: Integer): string;
+begin
+  case ACategory of
+    TWEAK_CAT_GENERAL:  Result := 'General';
+    TWEAK_CAT_GRAPHICS: Result := 'Graphics';
+    TWEAK_CAT_PERF:     Result := 'Performance';
+    TWEAK_CAT_LATENCY:  Result := 'Latency reduction';
+    TWEAK_CAT_CUSTOM:   Result := 'Custom';
+  else
+    Result := '';
+  end;
+end;
 
 function GetTweakRowCheckBox(Form: Tgoverlayform; Index: Integer): TCheckBox;
 begin
@@ -256,7 +282,7 @@ begin
   for i := 0 to TWEAK_ROW_COUNT - 1 do
   begin
     FForm.FTweaksGrid.Cells[0, i + 1] := '0';
-    FForm.FTweaksGrid.Cells[1, i + 1] := TWEAK_ROWS[i].Category;
+    FForm.FTweaksGrid.Cells[1, i + 1] := TweakCategoryName(TWEAK_ROWS[i].Category);
     FForm.FTweaksGrid.Cells[2, i + 1] := TWEAK_ROWS[i].VarName;
     FForm.FTweaksGrid.Cells[3, i + 1] := TWEAK_ROWS[i].Description;
   end;
@@ -516,10 +542,10 @@ begin
 
   ItemH := ItemHeight;
   HeadH := HeaderHeight;
-  CatNames[0] := 'General';
-  CatNames[1] := 'Graphics';
-  CatNames[2] := 'Performance';
-  CatNames[3] := 'Latency reduction';
+  CatNames[0] := TweakCategoryName(TWEAK_CAT_GENERAL);
+  CatNames[1] := TweakCategoryName(TWEAK_CAT_GRAPHICS);
+  CatNames[2] := TweakCategoryName(TWEAK_CAT_PERF);
+  CatNames[3] := TweakCategoryName(TWEAK_CAT_LATENCY);
   CatExpanded := FForm.FTweaksCatExpanded;
 
   Y := -FForm.FTweaksScrollPos;
@@ -546,7 +572,7 @@ begin
       CatItemCount := 0;
       for i := 0 to TWEAK_ROW_COUNT - 1 do
       begin
-        if TWEAK_ROWS[i].Category <> CatNames[CatIdx] then Continue;
+        if TWEAK_ROWS[i].Category <> CatIdx then Continue;
         Chk := GetTweakRowCheckBox(FForm, i);
         if Is2Col then
         begin
@@ -578,7 +604,7 @@ begin
 
   // Custom variables header
   R := Rect(0, Y, PB.Width, Y + HeadH);
-  DrawHeader(PB.Canvas, R, 'Custom', '✎', True, HoverIdx = RowIdx);
+  DrawHeader(PB.Canvas, R, TweakCategoryName(TWEAK_CAT_CUSTOM), '✎', True, HoverIdx = RowIdx);
   Inc(Y, HeadH);
   Inc(RowIdx);
 
@@ -634,7 +660,7 @@ var
   PB: TPaintBox;
   OldHover, ItemH, HeadH, RowIdx, i, CatIdx: Integer;
   YPos, ColWidth, Col, CatItemCount, CustomItemCount, ItemX, ItemW: Integer;
-  CatName, TweakHint: string;
+  TweakHint: string;
   Is2Col: Boolean;
 begin
   PB := Sender as TPaintBox;
@@ -651,13 +677,6 @@ begin
 
   for CatIdx := 0 to 3 do
   begin
-    case CatIdx of
-      0: CatName := 'General';
-      1: CatName := 'Graphics';
-      2: CatName := 'Performance';
-      3: CatName := 'Latency reduction';
-    end;
-
     // Header
     if (Y >= YPos) and (Y < YPos + HeadH) then
     begin
@@ -672,7 +691,7 @@ begin
       CatItemCount := 0;
       for i := 0 to TWEAK_ROW_COUNT - 1 do
       begin
-        if TWEAK_ROWS[i].Category <> CatName then Continue;
+        if TWEAK_ROWS[i].Category <> CatIdx then Continue;
         if Is2Col then
         begin
           Col := CatItemCount mod 2;
@@ -683,7 +702,7 @@ begin
             FForm.FTweaksHoverIdx := RowIdx;
             if TWEAK_ROWS[i].VarName = 'PROTON_VKD3D_LOWLATENCY=1' then
               TweakHint := 'Works only with proton-cachyos'
-            else if CatName = 'Latency reduction' then
+            else if CatIdx = TWEAK_CAT_LATENCY then
               TweakHint := 'Needs Korthos low latency layer installed';
             Break;
           end;
@@ -698,7 +717,7 @@ begin
             FForm.FTweaksHoverIdx := RowIdx;
             if TWEAK_ROWS[i].VarName = 'PROTON_VKD3D_LOWLATENCY=1' then
               TweakHint := 'Works only with proton-cachyos'
-            else if CatName = 'Latency reduction' then
+            else if CatIdx = TWEAK_CAT_LATENCY then
               TweakHint := 'Needs Korthos low latency layer installed';
             Break;
           end;
@@ -780,7 +799,6 @@ var
   PB: TPaintBox;
   ItemH, HeadH, RowIdx, i, CatIdx: Integer;
   YPos, ColWidth, Col, CatItemCount, CustomItemCount, ItemX, ItemW: Integer;
-  CatName: string;
   ToggleX: Integer;
   Chk: TCheckBox;
   Is2Col: Boolean;
@@ -796,13 +814,6 @@ begin
 
   for CatIdx := 0 to 3 do
   begin
-    case CatIdx of
-      0: CatName := 'General';
-      1: CatName := 'Graphics';
-      2: CatName := 'Performance';
-      3: CatName := 'Latency reduction';
-    end;
-
     // Header click = toggle expand
     if (Y >= YPos) and (Y < YPos + HeadH) then
     begin
@@ -818,7 +829,7 @@ begin
       CatItemCount := 0;
       for i := 0 to TWEAK_ROW_COUNT - 1 do
       begin
-        if TWEAK_ROWS[i].Category <> CatName then Continue;
+        if TWEAK_ROWS[i].Category <> CatIdx then Continue;
         if Is2Col then
         begin
           Col := CatItemCount mod 2;
@@ -1018,7 +1029,7 @@ begin
   Row := FForm.FTweaksGrid.RowCount;
   FForm.FTweaksGrid.RowCount := Row + 1;
   FForm.FTweaksGrid.Cells[0, Row] := '1';
-  FForm.FTweaksGrid.Cells[1, Row] := 'Custom';
+  FForm.FTweaksGrid.Cells[1, Row] := TweakCategoryName(TWEAK_CAT_CUSTOM);
   FForm.FTweaksGrid.Cells[2, Row] := Val;
   FForm.FTweaksGrid.Cells[3, Row] := '';
   FForm.FTweaksPaintBox.Invalidate;
@@ -1528,7 +1539,7 @@ begin
           Row := FForm.FTweaksGrid.RowCount;
           FForm.FTweaksGrid.RowCount := Row + 1;
           FForm.FTweaksGrid.Cells[0, Row] := '1';
-          FForm.FTweaksGrid.Cells[1, Row] := 'Custom';
+          FForm.FTweaksGrid.Cells[1, Row] := TweakCategoryName(TWEAK_CAT_CUSTOM);
           FForm.FTweaksGrid.Cells[2, Row] := Key + '=' + Val;
           FForm.FTweaksGrid.Cells[3, Row] := '';
         end;


### PR DESCRIPTION
Follow-up to #374. That one fixed the MangoHud config writer; the same habit turned up in five more spots, so I went through them.

- Tweaks tab: `TWEAK_ROWS[i].Category` holds the header caption itself, and Paint/MouseMove/MouseDown each re-list the four literals to match rows against. Reword a header and the tab draws four empty sections, hover hints and colour gone, no error anywhere. Rows now carry an id (`TWEAK_CAT_*`) and `TweakCategoryName` is the only place the caption comes from.
- Games tab: `RemoveFolderMenuItemClick` recovers the folder by chopping `'Remove: '` off the menu caption. It reads the item's `Hint` now, which the builder already fills with the exact path.
- OptiScaler card: the version tag was cut out of the notice with a hardcoded 17, the length of `'Update Available '`. The tag lives in the label's `Hint`, the caption is composed from it.
- `GOVERLAY_PACKAGE_TYPE` was the Home tab's installation-type text, lowercased. Split into `GetGOverlayPackageType` (identifier) and `GetGOverlayInstallationType` (display).
- `CheckDependencies` output is printed to the user and searched for `'mangohud'`, `'gamemode'` and friends at the same time, with the literals repeated at both ends. Both sides share `DEP_*` constants now.

Behaviour is the same, with one exception in the app's favour: while the update check runs the notice says `Searching for updates...`, the old prefix test did not match it and the sentence got copied into the status card as if it were a version tag. The card keeps the installed version until a real tag arrives.

Checked with `lazbuild goverlay.lpi --bm=Release`, plus `make test-logic` and `make test-gui`, unmodified. I also compared all 29 tweak rows against main one by one — each lands in the same category. Note `make test-gui` only runs for me with `GOVERLAY_TEST=1` in the environment: on current main it hangs on the new stdout hook, which is unrelated to this branch and I will report it separately.

What sent me looking was translation work — every one of these breaks quietly the moment a caption is reworded.
