### PR TITLE
fix(i18n): stop the catalogue from translating configuration values, and polish the Russian captions

### DIFF
--- a/goverlay_i18n.pas
+++ b/goverlay_i18n.pas
@@ -31,12 +31,69 @@ function GetLanguagesDir: string;
 implementation
 
 uses
-  SysUtils, LCLTranslator, bgmod_resources;
+  Classes, SysUtils, TypInfo, LResources, LCLTranslator, bgmod_resources;
 
 const
   // Base name of the catalogues: goverlay.pot for the template that the IDE
   // regenerates, goverlay.<lang>.po for a translation.
   LOCALE_FILE_NAME = 'goverlay';
+
+  // Published property that carries a value rather than a label. See
+  // TValueSafeTranslator.
+  VALUE_PROPERTY = 'Text';
+
+type
+
+  { TValueSafeTranslator }
+
+  // Wraps the translator the LCL installs and keeps the Text property out of
+  // its reach.
+  //
+  // Text on an edit or a combo box is not something the user reads, it is
+  // something the program writes down: vkbtogglekeyCombobox.Text ends up as
+  // "toggleKey = Home" in vkBasalt.conf, filenameComboBox.Text as OptiScaler's
+  // DLL name, hudonoffComboBox.Text as MangoHud's "toggle_hud = Shift_R+F12",
+  // shortcutkeyComboBox.Text as a raw key code. Every one of those defaults is
+  // also an entry of the Items list next to it, and Items are not translated at
+  // all, so a translated Text can only end up disagreeing with the list it was
+  // picked from and putting a word MangoHud and vkBasalt do not know into a
+  // configuration file.
+  //
+  // Captions, hints and TextHint - the placeholder property meant for prompts -
+  // are passed straight through.
+  TValueSafeTranslator = class(TAbstractTranslator)
+  private
+    FInner: TAbstractTranslator;
+  public
+    constructor Create(AInner: TAbstractTranslator);
+    destructor Destroy; override;
+    procedure TranslateStringProperty(Sender: TObject; const Instance: TPersistent;
+      PropInfo: PPropInfo; var Content: string); override;
+  end;
+
+constructor TValueSafeTranslator.Create(AInner: TAbstractTranslator);
+begin
+  inherited Create;
+  // Takes ownership: LCLTranslator frees whatever LRSTranslator points at.
+  FInner := AInner;
+end;
+
+destructor TValueSafeTranslator.Destroy;
+begin
+  FreeAndNil(FInner);
+  inherited Destroy;
+end;
+
+procedure TValueSafeTranslator.TranslateStringProperty(Sender: TObject;
+  const Instance: TPersistent; PropInfo: PPropInfo; var Content: string);
+begin
+  if (PropInfo = nil) or (FInner = nil) then
+    Exit;
+  // Leaving Content alone keeps the value the form was streamed with.
+  if SameText(PropInfo^.Name, VALUE_PROPERTY) then
+    Exit;
+  FInner.TranslateStringProperty(Sender, Instance, PropInfo, Content);
+end;
 
 function GetLanguagesDir: string;
 begin
@@ -60,6 +117,12 @@ begin
   // walk over and re-translate; the translator installed here does the work
   // while the forms are being streamed in.
   SetDefaultLang('', Dir, LOCALE_FILE_NAME, False);
+
+  // SetDefaultLang leaves its translator in LRSTranslator. Wrap it before the
+  // first form is streamed so that no catalogue, in any language, can rewrite a
+  // Text property into a configuration file.
+  if LRSTranslator <> nil then
+    LRSTranslator := TValueSafeTranslator.Create(LRSTranslator);
 end;
 
 end.

--- a/languages/goverlay.ru.po
+++ b/languages/goverlay.ru.po
@@ -465,7 +465,7 @@ msgstr ""
 
 #: tblacklistform.blacklistlabel.caption
 msgid "Enter application name to ignore MangoHud"
-msgstr "Введите имя приложения, которое MangoHud должен игнорировать"
+msgstr "Приложение, которое MangoHud игнорирует"
 
 #: tblacklistform.caption
 msgctxt "tblacklistform.caption"
@@ -482,7 +482,7 @@ msgstr "Удалить выбранное приложение"
 
 #: tgoverlayform.activegpulabel.caption
 msgid "Active GPU"
-msgstr "Активный ГП"
+msgstr "Активный GPU"
 
 #: tgoverlayform.actprotonlogscheckbox.caption
 msgid "Active Proton Logs"
@@ -557,7 +557,7 @@ msgstr "Определено автоматически"
 
 #: tgoverlayform.autouploadcheckbox.caption
 msgid "Autoupload results"
-msgstr "Отправлять результаты"
+msgstr "Автоотправка"
 
 #: tgoverlayform.autouploadcheckbox.hint
 msgid "Enables automatic uploads of logs to flightlessmango.com"
@@ -632,7 +632,7 @@ msgstr ""
 
 #: tgoverlayform.checkupdbitbtn.caption
 msgid "Check updates"
-msgstr "Проверить обновления"
+msgstr "Проверить"
 
 #: tgoverlayform.colorthemelabel.caption
 msgid "Color Theme"
@@ -676,7 +676,7 @@ msgstr "Частота ядра"
 
 #: tgoverlayform.cpugroupbox.caption
 msgid "CPU / Memory"
-msgstr "ЦП / память"
+msgstr "CPU / память"
 
 #: tgoverlayform.cpuload1colorbutton.hint
 msgctxt "tgoverlayform.cpuload1colorbutton.hint"
@@ -709,15 +709,15 @@ msgstr "Основные показатели"
 
 #: tgoverlayform.cpunameedit.texthint
 msgid "-- CPU Model --"
-msgstr "-- Модель ЦП --"
+msgstr "-- Модель CPU --"
 
 #: tgoverlayform.cpupowercheckbox.caption
 msgid "CPU Power"
-msgstr "Мощность ЦП"
+msgstr "Мощность CPU"
 
 #: tgoverlayform.cputempcheckbox.caption
 msgid "CPU temp"
-msgstr "Температура ЦП"
+msgstr "Температура CPU"
 
 #: tgoverlayform.cputemplabel.caption
 msgid "Temperature / Power"
@@ -794,7 +794,7 @@ msgstr ""
 
 #: tgoverlayform.displayservercheckbox.caption
 msgid "Display Server"
-msgstr "Сервер отображения"
+msgstr "Тип сеанса"
 
 #: tgoverlayform.displayservercheckbox.hint
 msgid "Display if your session is x11 or wayland"
@@ -995,7 +995,7 @@ msgstr ""
 
 #: tgoverlayform.forcelatencyflexcheckbox.caption
 msgid "Force LatencyFlex"
-msgstr "Принудительный LatencyFlex"
+msgstr "Всегда LatencyFlex"
 
 #: tgoverlayform.forcelatencyflexcheckbox.hint
 msgid "Useful in native fsg fg games"
@@ -1015,7 +1015,7 @@ msgstr ""
 
 #: tgoverlayform.forcereflexcheckbox.caption
 msgid "Force Reflex"
-msgstr "Принудительный Reflex"
+msgstr "Всегда Reflex"
 
 #: tgoverlayform.forcereflexcheckbox.hint
 msgctxt "tgoverlayform.forcereflexcheckbox.hint"
@@ -1348,7 +1348,7 @@ msgstr ""
 
 #: tgoverlayform.gpudrivergroupbox.caption
 msgid "GPU Driver"
-msgstr "Драйвер ГП"
+msgstr "Драйвер GPU"
 
 #: tgoverlayform.gpuefficiencycheckbox.caption
 msgctxt "tgoverlayform.gpuefficiencycheckbox.caption"
@@ -1372,7 +1372,7 @@ msgstr "Частота ядра"
 #: tgoverlayform.gpugroupbox.caption
 msgctxt "tgoverlayform.gpugroupbox.caption"
 msgid "GPU"
-msgstr "ГП"
+msgstr "GPU"
 
 #: tgoverlayform.gpuinfolabel.caption
 msgctxt "tgoverlayform.gpuinfolabel.caption"
@@ -1417,7 +1417,7 @@ msgstr "Модель"
 
 #: tgoverlayform.gpunameedit.texthint
 msgid "-- GPU NAME --"
-msgstr "-- НАЗВАНИЕ ГП --"
+msgstr "-- НАЗВАНИЕ GPU --"
 
 #: tgoverlayform.gpupowercheckbox.caption
 msgctxt "tgoverlayform.gpupowercheckbox.caption"
@@ -1452,7 +1452,7 @@ msgstr "Показывает, идёт ли троттлинг ГП по мощ�
 
 #: tgoverlayform.gputhrottlinggraphcheckbox.caption
 msgid "Throttling  graph"
-msgstr "График троттлинга"
+msgstr "На графике"
 
 #: tgoverlayform.gputhrottlinggraphcheckbox.hint
 msgid "Same as throttling_status but displays throttling in the frametime graph and only power and temp throttling"
@@ -1989,7 +1989,7 @@ msgstr "Видеопамять, занятая процессом"
 
 #: tgoverlayform.ramtempcheckbox.caption
 msgid "RAM temp"
-msgstr "Температура ОЗУ"
+msgstr "Температура RAM"
 
 #: tgoverlayform.ramtempcheckbox.hint
 msgid "only supports DDR5 with spd5118 driver"
@@ -1997,7 +1997,7 @@ msgstr "поддерживается только DDR5 с драйвером spd
 
 #: tgoverlayform.ramusagecheckbox.caption
 msgid "RAM"
-msgstr "ОЗУ"
+msgstr "RAM"
 
 #: tgoverlayform.reflexcombobox.hint
 msgctxt "tgoverlayform.reflexcombobox.hint"
@@ -2015,7 +2015,7 @@ msgstr ""
 
 #: tgoverlayform.refreshratecheckbox.caption
 msgid "Refresh rate*"
-msgstr "Частота обновления*"
+msgstr "Частота экрана*"
 
 #: tgoverlayform.refreshratecheckbox.hint
 msgid "*Gamescope only"
@@ -2167,7 +2167,7 @@ msgstr "Убрать эффект из списка"
 
 #: tgoverlayform.swapusagecheckbox.caption
 msgid "Swap"
-msgstr "Подкачка"
+msgstr "SWAP"
 
 #: tgoverlayform.systemgroupbox.caption
 msgid "System Information"
@@ -2210,7 +2210,7 @@ msgstr ""
 
 #: tgoverlayform.transparencylabel.caption
 msgid "Alpha"
-msgstr "Прозрачность"
+msgstr "Альфа"
 
 #: tgoverlayform.tweakslabel.caption
 msgctxt "tgoverlayform.tweakslabel.caption"
@@ -2330,7 +2330,7 @@ msgstr "Показывать режим вывода Vulkan"
 
 #: tgoverlayform.vramusagecheckbox.caption
 msgid "VRAM"
-msgstr "Видеопамять"
+msgstr "VRAM"
 
 #: tgoverlayform.vsynccombobox.hint
 msgid ""
@@ -2407,7 +2407,7 @@ msgstr ""
 
 #: tgoverlayform.winesynccheckbox.caption
 msgid "Wine Sync"
-msgstr "Синхронизация Wine"
+msgstr "Синхронизация"
 
 #: tgoverlayform.wow64checkbox.caption
 msgid "Use WOW64"

--- a/mangohud_ui.pas
+++ b/mangohud_ui.pas
@@ -583,10 +583,12 @@ begin
   // ·· [3] Fonts ····························································
   Place(fontComboBox,       FVisualSections[3], 6,  22);
   Place(fontcolorLabel,     FVisualSections[3], 6,  84);
-  Place(FontcolorButton,    FVisualSections[3], 52, 82);
+  Place(FontcolorButton,    FVisualSections[3], 60, 82);
   Place(fontLabel,          FVisualSections[3], 6,  142);
-  Place(fontsizeTrackBar,   FVisualSections[3], 40, 140);
-  Place(fontsizevalueLabel, FVisualSections[3], 40, 164);
+  // Slider and colour button start at 60, not 40/52: fontLabel needs room for a
+  // caption longer than "Size", and the two rows stay aligned with each other.
+  Place(fontsizeTrackBar,   FVisualSections[3], 60, 140);
+  Place(fontsizevalueLabel, FVisualSections[3], 60, 164);
   fontcolorLabel.Font.Color     := TextColor; fontcolorLabel.Transparent     := True;
   fontLabel.Font.Color          := TextColor; fontLabel.Transparent          := True;
   fontsizevalueLabel.Font.Color := TextColor; fontsizevalueLabel.Transparent := True;
@@ -947,7 +949,7 @@ begin
 
   // Fonts section: elastic widths (controls are relative to section panel)
   fontComboBox.Width     := SecW1 - 12;
-  fontsizeTrackBar.Width := SecW1 - 46;
+  fontsizeTrackBar.Width := SecW1 - 66;
   fontsizevalueLabel.Left := (SecW1 div 2) - 5;
 
   // Position section: Image fills panel, radio buttons proportional within it

--- a/overlayunit.lfm
+++ b/overlayunit.lfm
@@ -6624,7 +6624,7 @@ object goverlayform: Tgoverlayform
             Left = 5
             Height = 17
             Top = 63
-            Width = 100
+            Width = 116
             Align = alCustom
             AutoSize = False
             BorderSpacing.Top = 30


### PR DESCRIPTION
Follow-up to the i18n series, from running the program with `--lang=ru` and looking at it.

**The one that matters.** `tgoverlayform.vkbtogglekeycombobox.text` ended up in the catalogue as `msgid "Home"`. That Text is not a label — it is the vkBasalt toggle key, and it is written straight into `vkBasalt.conf` as `toggleKey = ...`. Translate it and the config gets a key vkBasalt does not know. The same is true of `filenameComboBox.Text` (OptiScaler's DLL name), `hudonoffComboBox.Text` (MangoHud's shortcut) and `shortcutkeyComboBox.Text`.

Rather than pulling those four msgids out one by one, the first commit wraps the translator that `SetDefaultLang` installs and drops the `Text` property before it can reach any catalogue. Captions, hints and TextHint pass through as before. It holds for every future language too, which the per-string approach would not.

Those defaults are all entries of the `Items` list next to them, and `Items` is never translated — so a translated `Text` could only ever disagree with its own list.

**The rest is cosmetic.** Two labels overlapped their sliders and nine captions were cut off in Russian where English fits, so those captions are shortened and two controls moved 20px right.

CPU, GPU and RAM go back to Latin in the short captions: each of those checkboxes enables an element MangoHud draws over the game in Latin, so the caption should match what the user actually sees. The Russian words stay in the hints.

Separate, and not mine to fix here: `Log Versioning` is cut off in English already.

Checked with `lazbuild goverlay.lpi --bm=Release` and `make test-logic` (0 failures).
