### PR TITLE
test: call RestoreStdoutHook before the sandbox re-exec

### DIFF
--- a/tests/common/test_isolation.pas
+++ b/tests/common/test_isolation.pas
@@ -12,7 +12,7 @@ procedure CleanupIsolatedEnvironment(ASuccess: Boolean);
 implementation
 
 uses
-  SysUtils, FileUtil, BaseUnix;
+  SysUtils, FileUtil, BaseUnix, apputils;
 
 {$IFDEF UNIX}
 // FPC 3.2 RTL ships no setenv wrapper; bind libc directly (test programs
@@ -93,6 +93,12 @@ begin
   for i := 0 to ParamCount do
     Args[i] := PChar(ParamStr(i));
   Args[ParamCount + 1] := nil;
+
+  // fpDup2 clears FD_CLOEXEC on the descriptor it writes to, so fds 1 and 2
+  // survive execv while the pipe's read end (CLOEXEC) and its reader thread do
+  // not. The child would then inherit a pipe nobody reads and die of SIGPIPE on
+  // its first WriteLn. Put the real stdout/stderr back before handing over.
+  RestoreStdoutHook;
   execv(PChar('/proc/self/exe'), PPChar(@Args[0]));
 
   // Only reached if exec fails


### PR DESCRIPTION
The patch I offered in #381. One call, plus a comment explaining why it is there.

Your fix made the suite pass, but what keeps it passing is the `Pos('test', ExeName) > 0` guard in `InstallStdoutHook` — gui_tests never reaches the FD_CLOEXEC code. Rename the same binary so the guard misses and it falls over:

```
$ make test-gui                                   # 62 tests, 0 failures
$ cp tests/gui/gui_tests tests/gui/guisuite
$ ./tests/gui/guisuite > out.txt 2>&1; echo $?
141                                               # SIGPIPE
$ wc -c out.txt
0 out.txt
```

`dup2` clears FD_CLOEXEC on the descriptor it writes to, so fds 1 and 2 outlive `execv` while the pipe's read end and its reader thread do not. The child gets two descriptors on a pipe nobody holds and dies on its first `WriteLn`.

`RestoreStdoutHook` already does the right thing, it just has no callers. Calling it before the re-exec puts the saved descriptors back, and `guisuite` runs to the end: exit 0, 62 tests, 0 failures. `make test-logic` (6 tests) and `make test-gui` (62 tests) both stay green, and `lazbuild --bm=Release` builds clean. Arch, fpc 3.2.2, Lazarus 4.8, qt6.

The name check can stay or go — with this in place it is no longer load-bearing.

Closes #381.
