### PR TITLE
test: resolve the sandbox path before trusting the prefix check

### DIFF
--- a/tests/common/test_isolation.pas
+++ b/tests/common/test_isolation.pas
@@ -27,11 +27,21 @@ var
 
 function IsSafeSandboxDir(const ADir: string): Boolean;
 var
-  TempPrefix: string;
+  TempPrefix, Resolved: string;
 begin
   if ADir = '' then Exit(False);
+
+  // Compare resolved paths, never the raw string. A path such as
+  // '<tmp>/goverlay_test_x/../../home/user' passes any prefix test while the
+  // kernel resolves it to '/home/user' - and DeleteDirectory follows the
+  // resolved path, not the string that was checked. Refuse traversal outright
+  // and then measure what the path actually points at.
+  if Pos(PathDelim + '..' + PathDelim,
+         PathDelim + ADir + PathDelim) > 0 then Exit(False);
+
+  Resolved := ExcludeTrailingPathDelimiter(ExpandFileName(ADir));
   TempPrefix := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'goverlay_test_';
-  Result := (Pos(TempPrefix, ADir) = 1) and (Length(ADir) > Length(TempPrefix));
+  Result := (Pos(TempPrefix, Resolved) = 1) and (Length(Resolved) > Length(TempPrefix));
 end;
 
 function IsolatedHome: string;

--- a/tests/logic/logic_test_cases.pas
+++ b/tests/logic/logic_test_cases.pas
@@ -24,6 +24,8 @@ type
   published
     procedure TestIsSafeSandboxDirValid;
     procedure TestIsSafeSandboxDirRejectsUnsafePaths;
+    procedure TestIsSafeSandboxDirRejectsTraversal;
+    procedure TestIsSafeSandboxDirAcceptsDottedNames;
   end;
 
 implementation
@@ -145,6 +147,45 @@ begin
   AssertFalse('Base temp directory rejected', IsSafeSandboxDir(GetTempDir(False)));
   AssertFalse('Temp prefix alone rejected', IsSafeSandboxDir(IncludeTrailingPathDelimiter(GetTempDir(False)) + 'goverlay_test_'));
   AssertFalse('Arbitrary temp folder rejected', IsSafeSandboxDir(IncludeTrailingPathDelimiter(GetTempDir(False)) + 'other_folder'));
+end;
+
+// The paths below all start with the sandbox prefix, so a string comparison
+// accepts every one of them - while the kernel resolves them outside the
+// sandbox, which is where DeleteDirectory would then do its work.
+procedure TSandboxIsolationTests.TestIsSafeSandboxDirRejectsTraversal;
+var
+  Prefix: string;
+begin
+  Prefix := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'goverlay_test_x';
+
+  AssertFalse('Escape to a home directory rejected',
+    IsSafeSandboxDir(Prefix + '/../../home/testuser'));
+  AssertFalse('Escape to filesystem root rejected',
+    IsSafeSandboxDir(Prefix + '/../..'));
+  AssertFalse('Escape to the temp root rejected',
+    IsSafeSandboxDir(Prefix + '/..'));
+  AssertFalse('Trailing traversal rejected',
+    IsSafeSandboxDir(Prefix + '/subdir/../../'));
+  AssertFalse('Traversal in the middle of a longer path rejected',
+    IsSafeSandboxDir(Prefix + '/a/../../../etc/skel'));
+  AssertFalse('Traversal that also leaves the temp root rejected',
+    IsSafeSandboxDir(Prefix + '/../../../root'));
+
+  // Landing back inside the sandbox is still refused: a directory about to be
+  // deleted recursively is not the place to trust a path that needs resolving.
+  AssertFalse('Traversal that resolves back inside is still rejected',
+    IsSafeSandboxDir(Prefix + '/subdir/..'));
+end;
+
+procedure TSandboxIsolationTests.TestIsSafeSandboxDirAcceptsDottedNames;
+var
+  Prefix: string;
+begin
+  // Dots are only dangerous as a whole path component; they are legal in names.
+  Prefix := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'goverlay_test_';
+  AssertTrue('Name containing dots accepted', IsSafeSandboxDir(Prefix + '12345..678'));
+  AssertTrue('Name ending in dots accepted', IsSafeSandboxDir(Prefix + '12345678..'));
+  AssertTrue('Trailing slash accepted', IsSafeSandboxDir(Prefix + '12345678/'));
 end;
 
 initialization


### PR DESCRIPTION
The `..` hole I mentioned at the end of #382. Everything else in that issue stays fixed; this is only the string comparison in `IsSafeSandboxDir`.

Reproducer, entirely inside a throwaway tree — no real home involved:

```
SB=/tmp/canary
mkdir -p $SB/tmp/goverlay_test_x $SB/victimhome/.config/goverlay
echo irreplaceable > $SB/victimhome/thesis.txt
TRAV=$SB/tmp/goverlay_test_x/../../victimhome
env -i PATH=/usr/bin HOME=$TRAV TMPDIR=$SB/tmp GOVERLAY_TEST=1 \
    GOVERLAY_TEST_SANDBOX_DIR=$TRAV ./tests/logic/logic_tests
```

Before: 6 tests green, `[test] Isolated HOME cleaned up.`, and `$SB/victimhome` and everything under it is gone. The path starts with the sandbox prefix, so `Pos(...) = 1` says yes, while `DirectoryExists` and `DeleteDirectory` resolve it for real and land two levels up. After: `[test] FATAL: Invalid or unsafe isolated HOME detected`, exit 2, canaries intact.

The fix refuses any `..` component and compares `ExpandFileName` output rather than the raw string. I also refuse a `..` that happens to resolve back inside the sandbox — a path that is about to be deleted recursively is not one I want to reason about twice.

Tests go 6 -> 8: the traversal shapes, plus the case that keeps `goverlay_test_12345..678` legal, since dots only matter as a whole path component.

`lazbuild --bm=Release` clean, `make test-logic` 8/8, `make test-gui` 62/62. Arch, fpc 3.2.2, Lazarus 4.8, qt6.

Refs #382.
