### PR TITLE
fix: read all of lsmod before deciding a module is missing

### DIFF
--- a/apputils.pas
+++ b/apputils.pas
@@ -427,22 +427,19 @@ end;
 
 function IsKernelModuleAvailable(const ModuleName: string): Boolean;
 var
-  AProcess: TProcess;
-  OutputLines: TStringList;
+  LsmodPath, Output: string;
 begin
   Result := False;
-  AProcess := TProcess.Create(nil);
-  OutputLines := TStringList.Create;
-  try
-    AProcess.Executable := FindDefaultExecutablePath('lsmod');
-    AProcess.Options := [poUsePipes];
-    AProcess.Execute;
-    OutputLines.LoadFromStream(AProcess.Output);
-    Result := OutputLines.Text.Contains(ModuleName);
-  finally
-    AProcess.Free;
-    OutputLines.Free;
-  end;
+  LsmodPath := FindDefaultExecutablePath('lsmod');
+  if LsmodPath = '' then Exit;
+
+  // Reading AProcess.Output straight after Execute only returns whatever has
+  // already reached the pipe - one 4 KiB page here - so every module past that
+  // point looks unloaded. RunCommand keeps draining until lsmod exits, without
+  // the 64 KiB deadlock that poWaitOnExit on its own would risk.
+  Output := '';
+  if RunCommand(LsmodPath, [], Output) then
+    Result := Output.Contains(ModuleName);
 end;
 
 function CheckDependencies(out Missing: TStringList): Boolean;

--- a/goverlay_system.pas
+++ b/goverlay_system.pas
@@ -346,22 +346,19 @@ end;
 // Function to check for kernel modules
 function IsKernelModuleAvailable(const ModuleName: string): Boolean;
 var
-  AProcess: TProcess;
-  OutputLines: TStringList;
+  LsmodPath, Output: string;
 begin
   Result := False;
-  AProcess := TProcess.Create(nil);
-  OutputLines := TStringList.Create;
-  try
-    AProcess.Executable := FindDefaultExecutablePath('lsmod');
-    AProcess.Options := [poUsePipes];
-    AProcess.Execute;
-    OutputLines.LoadFromStream(AProcess.Output);
-    Result := OutputLines.Text.Contains(ModuleName);
-  finally
-    AProcess.Free;
-    OutputLines.Free;
-  end;
+  LsmodPath := FindDefaultExecutablePath('lsmod');
+  if LsmodPath = '' then Exit;
+
+  // Reading AProcess.Output straight after Execute only returns whatever has
+  // already reached the pipe - one 4 KiB page here - so every module past that
+  // point looks unloaded. RunCommand keeps draining until lsmod exits, without
+  // the 64 KiB deadlock that poWaitOnExit on its own would risk.
+  Output := '';
+  if RunCommand(LsmodPath, [], Output) then
+    Result := Output.Contains(ModuleName);
 end;
 
 // Function to check for dependencies


### PR DESCRIPTION
The `lsmod` reader I flagged at the end of #387. Same code twice: `apputils.pas:428` and `goverlay_system.pas:347`.

Reading `AProcess.Output` right after `Execute` returns whatever has reached the pipe by then — one page. I compiled both versions verbatim and ran each 100 times on this machine, where `lsmod | wc -c` is 9183 across 191 modules:

```
before: aead found 0/100,   bytes read min=4097 max=4097
after:  aead found 100/100, bytes read min=9183 max=9183
```

`aead` is loaded here, it just sits past the 4 KiB mark. Not flaky — 4097 every single run. Against the patched `apputils` itself: `aead` 50/50, `nvidia` 50/50, `zenergy` (genuinely not loaded) 0/50.

Nothing is broken for users today, the only call site is commented out at `goverlay_system.pas:466`. I would rather it be right before someone uncomments it. `IsNvidiaModuleLoaded`, twenty lines above the copy, already waits.

I used `RunCommand` instead of adding `poWaitOnExit`, because waiting with `poUsePipes` deadlocks if the child ever writes past the 64 KiB pipe buffer, while `RunCommand` drains as it waits. Also an early exit when `lsmod` is not on PATH — today that path calls `Execute` with an empty `Executable` and raises.

The two copies are byte-identical and `goverlay_system` already uses `apputils`, so one of them could go. I left that out to keep this a bug fix; say the word and I will send it separately.

`lazbuild --bm=Release` clean, `make test-logic` 6/6, `make test-gui` 62/62. Arch, fpc 3.2.2, Lazarus 4.8, qt6.

Refs #387.
